### PR TITLE
Use portable shebang instead of hardcoded node path

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   target: 'node20',
   external: ['better-sqlite3', '@vlcn.io/crsqlite-allinone', '@vlcn.io/crsqlite', '@anthropic-ai/claude-agent-sdk'],
   banner: {
-    js: '#!/Users/mattpardini/.nvm/versions/node/v20.20.2/bin/node',
+    js: '#!/usr/bin/env node',
   },
   clean: true,
 });


### PR DESCRIPTION
## Summary
- Replaces machine-specific nvm node path (`#!/Users/mattpardini/.nvm/...`) with `#!/usr/bin/env node`
- Eliminates the need to edit `tsup.config.ts` when setting up on a new machine

## Test plan
- [ ] Run `npm run build` and verify the output binary has the correct shebang
- [ ] Run `think --version` to confirm it resolves node correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)