### PR TITLE
Add cortex support — team-scoped shared memory backed by git

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "think": "./dist/index.js"
   },
   "scripts": {
-    "build": "tsup && sed -i '' 's/from \"sqlite\"/from \"node:sqlite\"/' dist/index.js",
+    "build": "tsup && find dist -name '*.js' -exec sed -i '' 's/from \"sqlite\"/from \"node:sqlite\"/g' {} +",
     "dev": "tsx src/index.ts"
   },
   "dependencies": {

--- a/src/commands/cortex.ts
+++ b/src/commands/cortex.ts
@@ -1,0 +1,152 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import readline from 'node:readline';
+import { getConfig, saveConfig } from '../lib/config.js';
+import { ensureRepoCloned, branchExists, createOrphanBranch, listRemoteBranches } from '../lib/git.js';
+import { getEngramsDb, closeEngramsDb } from '../db/engrams.js';
+
+function prompt(question: string, defaultValue?: string): Promise<string> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(answer.trim() || defaultValue || '');
+    });
+  });
+}
+
+export const cortexCommand = new Command('cortex')
+  .description('Manage cortexes (team memory workspaces)');
+
+// think cortex setup
+cortexCommand.addCommand(new Command('setup')
+  .description('Configure the git repo for cortex storage')
+  .argument('[repo]', 'Git remote URL (e.g., git@github.com:org/hivedb.git)')
+  .action(async (repo?: string) => {
+    const config = getConfig();
+
+    if (!repo) {
+      repo = await prompt('Git repo URL for cortex storage: ');
+      if (!repo) {
+        console.error(chalk.red('Repo URL is required.'));
+        process.exit(1);
+      }
+    }
+
+    const author = await prompt(`Your name (for memory attribution): `, config.cortex?.author);
+    if (!author) {
+      console.error(chalk.red('Author name is required.'));
+      process.exit(1);
+    }
+
+    config.cortex = {
+      repo,
+      author,
+      active: config.cortex?.active,
+    };
+    saveConfig(config);
+
+    console.log(chalk.green('✓') + ` Cortex repo: ${repo}`);
+    console.log(chalk.green('✓') + ` Author: ${author}`);
+
+    // Clone the repo
+    ensureRepoCloned();
+    console.log(chalk.green('✓') + ' Repo cloned');
+  }));
+
+// think cortex create <name>
+cortexCommand.addCommand(new Command('create')
+  .argument('<name>', 'Cortex name (e.g., engineering, product)')
+  .description('Create a new cortex branch')
+  .action(async (name: string) => {
+    const config = getConfig();
+    if (!config.cortex?.repo) {
+      console.error(chalk.red('No cortex repo configured. Run: think cortex setup'));
+      process.exit(1);
+    }
+
+    ensureRepoCloned();
+
+    if (branchExists(name)) {
+      console.log(chalk.yellow(`Branch '${name}' already exists. Use: think cortex switch ${name}`));
+      return;
+    }
+
+    createOrphanBranch(name);
+
+    // Initialize the engram DB for this cortex
+    getEngramsDb(name);
+    closeEngramsDb(name);
+
+    // Set as active if no active cortex
+    if (!config.cortex.active) {
+      config.cortex.active = name;
+      saveConfig(config);
+    }
+
+    console.log(chalk.green('✓') + ` Created cortex: ${name}`);
+    if (config.cortex.active === name) {
+      console.log(chalk.dim('  Set as active cortex'));
+    }
+  }));
+
+// think cortex list
+cortexCommand.addCommand(new Command('list')
+  .description('Show all cortex branches')
+  .action(async () => {
+    const config = getConfig();
+    if (!config.cortex?.repo) {
+      console.log(chalk.dim('No cortex repo configured. Run: think cortex setup'));
+      return;
+    }
+
+    ensureRepoCloned();
+
+    const branches = listRemoteBranches();
+
+    if (branches.length === 0) {
+      console.log(chalk.dim('No cortex branches found. Run: think cortex create <name>'));
+      return;
+    }
+
+    for (const branch of branches) {
+      const marker = branch === config.cortex.active ? chalk.green('* ') : '  ';
+      console.log(`${marker}${branch}`);
+    }
+  }));
+
+// think cortex switch <name>
+cortexCommand.addCommand(new Command('switch')
+  .argument('<name>', 'Cortex name')
+  .description('Set the active cortex')
+  .action(async (name: string) => {
+    const config = getConfig();
+    if (!config.cortex?.repo) {
+      console.error(chalk.red('No cortex repo configured. Run: think cortex setup'));
+      process.exit(1);
+    }
+
+    ensureRepoCloned();
+
+    if (!branchExists(name)) {
+      console.error(chalk.red(`Cortex '${name}' does not exist. Run: think cortex create ${name}`));
+      process.exit(1);
+    }
+
+    config.cortex.active = name;
+    saveConfig(config);
+    console.log(chalk.green('✓') + ` Active cortex: ${name}`);
+  }));
+
+// think cortex current
+cortexCommand.addCommand(new Command('current')
+  .description('Show the active cortex')
+  .action(() => {
+    const config = getConfig();
+    const active = config.cortex?.active;
+    if (active) {
+      console.log(active);
+    } else {
+      console.log(chalk.dim('(no active cortex)'));
+    }
+  }));

--- a/src/commands/curate.ts
+++ b/src/commands/curate.ts
@@ -1,0 +1,137 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { getConfig } from '../lib/config.js';
+import { ensureRepoCloned, fetchBranch, readFileFromBranch, appendAndCommit } from '../lib/git.js';
+import { getPendingEngrams, markEvaluated, pruneExpiredEngrams } from '../db/engram-queries.js';
+import { closeEngramsDb } from '../db/engrams.js';
+import { readCuratorMd, assembleCurationPrompt, parseMemoriesJsonl, runCuration } from '../lib/curator.js';
+
+export const curateCommand = new Command('curate')
+  .description('Run curation: evaluate pending engrams and append memories to the cortex branch')
+  .option('--dry-run', 'Preview what would be committed without pushing')
+  .action(async (opts: { dryRun?: boolean }) => {
+    const config = getConfig();
+    const cortex = config.cortex?.active;
+
+    if (!cortex) {
+      console.error(chalk.red('No active cortex. Run: think cortex switch <name>'));
+      process.exit(1);
+    }
+
+    if (!config.cortex?.repo) {
+      console.error(chalk.red('No cortex repo configured. Run: think cortex setup'));
+      process.exit(1);
+    }
+
+    const author = config.cortex.author;
+
+    // 1. Ensure repo is cloned and fetch latest
+    ensureRepoCloned();
+    fetchBranch(cortex);
+
+    // 2. Read existing memories from branch
+    const memoriesRaw = readFileFromBranch(cortex, 'memories.jsonl') ?? '';
+    const existingMemories = parseMemoriesJsonl(memoriesRaw);
+
+    // 3. Read pending engrams
+    const pending = getPendingEngrams(cortex);
+    if (pending.length === 0) {
+      console.log(chalk.dim('No pending engrams to evaluate.'));
+      closeEngramsDb(cortex);
+      return;
+    }
+
+    console.log(chalk.cyan(`Evaluating ${pending.length} engrams against ${existingMemories.length} existing memories...`));
+
+    // 4. Read curator.md
+    const curatorMd = readCuratorMd();
+
+    // 5. Assemble and run curation prompt
+    const prompt = assembleCurationPrompt({
+      existingMemories,
+      curatorMd,
+      pendingEngrams: pending,
+      author,
+    });
+
+    let newEntries;
+    try {
+      newEntries = await runCuration(prompt);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(chalk.red(`Curation failed: ${message}`));
+      closeEngramsDb(cortex);
+      process.exit(1);
+    }
+
+    // Always set author and timestamp — don't trust the LLM to fill these correctly
+    for (const entry of newEntries) {
+      entry.author = author;
+      if (!entry.ts) entry.ts = new Date().toISOString();
+    }
+
+    // 6. Identify promoted and dropped engram IDs
+    const promotedIds = new Set<string>();
+    for (const entry of newEntries) {
+      for (const id of entry.source_ids) {
+        promotedIds.add(id);
+      }
+    }
+
+    const droppedIds = pending
+      .filter(e => !promotedIds.has(e.id))
+      .map(e => e.id);
+
+    // 7. Dry run — show preview and exit
+    if (opts.dryRun) {
+      console.log();
+      if (newEntries.length === 0) {
+        console.log(chalk.dim('Curator would produce no new memories.'));
+      } else {
+        console.log(chalk.cyan('Would append:'));
+        for (const entry of newEntries) {
+          console.log(chalk.green(`  + `) + `[${entry.ts}] ${entry.content}`);
+        }
+      }
+      console.log();
+      console.log(`${pending.length} evaluated, ${newEntries.length} would promote, ${droppedIds.length} would drop`);
+      closeEngramsDb(cortex);
+      return;
+    }
+
+    // 8. Append to memories.jsonl and push
+    if (newEntries.length > 0) {
+      const newLines = newEntries.map(e => JSON.stringify(e));
+      const commitMsg = `curate: ${author}, ${pending.length} engrams, ${newEntries.length} memories`;
+
+      try {
+        appendAndCommit(cortex, newLines, commitMsg);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(chalk.red(`Failed to push memories: ${message}`));
+        closeEngramsDb(cortex);
+        process.exit(1);
+      }
+    }
+
+    // 9. Mark engrams as evaluated
+    if (promotedIds.size > 0) {
+      markEvaluated(cortex, [...promotedIds], true);
+    }
+    if (droppedIds.length > 0) {
+      markEvaluated(cortex, droppedIds, false);
+    }
+
+    // 10. Prune expired engrams
+    const pruned = pruneExpiredEngrams(cortex);
+
+    // 11. Report
+    console.log();
+    console.log(`${chalk.green('✓')} Curation complete`);
+    console.log(`  ${pending.length} evaluated, ${newEntries.length} promoted, ${droppedIds.length} dropped`);
+    if (pruned > 0) {
+      console.log(`  ${pruned} expired engrams pruned`);
+    }
+
+    closeEngramsDb(cortex);
+  });

--- a/src/commands/curator-cmd.ts
+++ b/src/commands/curator-cmd.ts
@@ -1,0 +1,53 @@
+import { Command } from 'commander';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import chalk from 'chalk';
+import { getCuratorMdPath, ensureThinkDirs } from '../lib/paths.js';
+
+const CURATOR_TEMPLATE = `# Curator Guidance
+
+Tell your curator what you consider worth sharing with the team.
+This file is read by the curation process every time it runs.
+
+Examples:
+- "I work on infrastructure — focus on deploy events, outages, and migration decisions."
+- "Track product decisions, customer feedback themes, and roadmap shifts."
+- "Skip standup notes and calendar changes."
+
+Write your guidance below this line:
+
+`;
+
+export const curatorCommand = new Command('curator')
+  .description('Manage personal curator guidance');
+
+curatorCommand.addCommand(new Command('edit')
+  .description('Edit your curator guidance in $EDITOR')
+  .action(() => {
+    ensureThinkDirs();
+    const mdPath = getCuratorMdPath();
+
+    if (!fs.existsSync(mdPath)) {
+      fs.writeFileSync(mdPath, CURATOR_TEMPLATE, 'utf-8');
+    }
+
+    const editor = process.env.EDITOR || 'vi';
+    const result = spawnSync(editor, [mdPath], { stdio: 'inherit' });
+
+    if (result.status === 0) {
+      console.log(chalk.green('✓') + ` Curator guidance saved at ${mdPath}`);
+    } else {
+      console.error(chalk.red('Editor exited with an error.'));
+    }
+  }));
+
+curatorCommand.addCommand(new Command('show')
+  .description('Print your current curator guidance')
+  .action(() => {
+    const mdPath = getCuratorMdPath();
+    if (fs.existsSync(mdPath)) {
+      console.log(fs.readFileSync(mdPath, 'utf-8'));
+    } else {
+      console.log(chalk.dim('No curator guidance configured. Run: think curator edit'));
+    }
+  }));

--- a/src/commands/log.ts
+++ b/src/commands/log.ts
@@ -6,18 +6,6 @@ import { getConfig } from '../lib/config.js';
 import { insertEngram } from '../db/engram-queries.js';
 import { closeEngramsDb } from '../db/engrams.js';
 
-function getActiveCortex(): string | undefined {
-  const config = getConfig();
-  // Commander stores global opts on the root program — access via process.argv parsing
-  const cortexFlagIdx = process.argv.indexOf('-C');
-  const cortexFlagLongIdx = process.argv.indexOf('--cortex');
-  const flagIdx = cortexFlagIdx !== -1 ? cortexFlagIdx : cortexFlagLongIdx;
-  if (flagIdx !== -1 && process.argv[flagIdx + 1]) {
-    return process.argv[flagIdx + 1];
-  }
-  return config.cortex?.active;
-}
-
 export const logCommand = new Command('log')
   .description('Log a note or entry')
   .argument('<message>', 'The message to log')
@@ -53,8 +41,10 @@ export const syncCommand = new Command('sync')
   .option('-s, --source <source>', 'Source of the entry', 'manual')
   .option('-t, --tags <tags>', 'Comma-separated tags')
   .option('--silent', 'Suppress output')
-  .action((message: string, opts: { source: string; tags?: string; silent?: boolean }) => {
-    const cortex = getActiveCortex();
+  .action(function (this: Command, message: string, opts: { source: string; tags?: string; silent?: boolean }) {
+    const globalOpts = this.optsWithGlobals() as { cortex?: string };
+    const config = getConfig();
+    const cortex = globalOpts.cortex ?? config.cortex?.active;
 
     if (cortex) {
       // Route to cortex engram DB

--- a/src/commands/log.ts
+++ b/src/commands/log.ts
@@ -2,6 +2,21 @@ import { Command } from 'commander';
 import chalk from 'chalk';
 import { insertEntry } from '../db/queries.js';
 import { closeDb } from '../db/client.js';
+import { getConfig } from '../lib/config.js';
+import { insertEngram } from '../db/engram-queries.js';
+import { closeEngramsDb } from '../db/engrams.js';
+
+function getActiveCortex(): string | undefined {
+  const config = getConfig();
+  // Commander stores global opts on the root program — access via process.argv parsing
+  const cortexFlagIdx = process.argv.indexOf('-C');
+  const cortexFlagLongIdx = process.argv.indexOf('--cortex');
+  const flagIdx = cortexFlagIdx !== -1 ? cortexFlagIdx : cortexFlagLongIdx;
+  if (flagIdx !== -1 && process.argv[flagIdx + 1]) {
+    return process.argv[flagIdx + 1];
+  }
+  return config.cortex?.active;
+}
 
 export const logCommand = new Command('log')
   .description('Log a note or entry')
@@ -39,23 +54,40 @@ export const syncCommand = new Command('sync')
   .option('-t, --tags <tags>', 'Comma-separated tags')
   .option('--silent', 'Suppress output')
   .action((message: string, opts: { source: string; tags?: string; silent?: boolean }) => {
-    const tags = opts.tags ? opts.tags.split(',').map(t => t.trim()) : undefined;
-    const entry = insertEntry({
-      content: message,
-      source: opts.source,
-      category: 'sync',
-      tags,
-    });
+    const cortex = getActiveCortex();
 
-    if (!opts.silent) {
-      const catBadge = chalk.dim('[sync]');
-      const ts = chalk.gray(entry.timestamp.slice(0, 16).replace('T', ' '));
-      console.log(`${chalk.green('✓')} Logged ${catBadge} ${ts}`);
-      console.log(`  ${entry.content}`);
-      if (tags && tags.length > 0) {
-        console.log(`  ${chalk.cyan('tags:')} ${tags.join(', ')}`);
+    if (cortex) {
+      // Route to cortex engram DB
+      const engram = insertEngram(cortex, { content: message });
+
+      if (!opts.silent) {
+        const badge = chalk.cyan(`[${cortex}]`);
+        const ts = chalk.gray(engram.created_at.slice(0, 16).replace('T', ' '));
+        console.log(`${chalk.green('✓')} ${badge} engram saved ${ts}`);
+        console.log(`  ${engram.content}`);
       }
-    }
 
-    closeDb();
+      closeEngramsDb(cortex);
+    } else {
+      // Original path — local think.db
+      const tags = opts.tags ? opts.tags.split(',').map(t => t.trim()) : undefined;
+      const entry = insertEntry({
+        content: message,
+        source: opts.source,
+        category: 'sync',
+        tags,
+      });
+
+      if (!opts.silent) {
+        const catBadge = chalk.dim('[sync]');
+        const ts = chalk.gray(entry.timestamp.slice(0, 16).replace('T', ' '));
+        console.log(`${chalk.green('✓')} Logged ${catBadge} ${ts}`);
+        console.log(`  ${entry.content}`);
+        if (tags && tags.length > 0) {
+          console.log(`  ${chalk.cyan('tags:')} ${tags.join(', ')}`);
+        }
+      }
+
+      closeDb();
+    }
   });

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -1,0 +1,46 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { getConfig } from '../lib/config.js';
+import { ensureRepoCloned, fetchBranch, readFileFromBranch, getFileLog } from '../lib/git.js';
+import { parseMemoriesJsonl } from '../lib/curator.js';
+
+export const memoryCommand = new Command('memory')
+  .description('Show current memories from the cortex branch')
+  .option('--history', 'Show git log for memories.jsonl')
+  .action(async (opts: { history?: boolean }) => {
+    const config = getConfig();
+    const cortex = config.cortex?.active;
+
+    if (!cortex) {
+      console.error(chalk.red('No active cortex. Run: think cortex switch <name>'));
+      process.exit(1);
+    }
+
+    ensureRepoCloned();
+    fetchBranch(cortex);
+
+    if (opts.history) {
+      const log = getFileLog(cortex, 'memories.jsonl');
+      if (log) {
+        console.log(log);
+      } else {
+        console.log(chalk.dim('No history.'));
+      }
+      return;
+    }
+
+    const memoriesRaw = readFileFromBranch(cortex, 'memories.jsonl') ?? '';
+    const memories = parseMemoriesJsonl(memoriesRaw);
+
+    if (memories.length === 0) {
+      console.log(chalk.dim('No memories yet. Run: think curate'));
+      return;
+    }
+
+    for (const m of memories) {
+      const ts = m.ts.slice(0, 16).replace('T', ' ');
+      console.log(`${chalk.gray(ts)}  ${chalk.dim(m.author + ':')} ${m.content}`);
+    }
+
+    console.log(chalk.dim(`\n${memories.length} memories`));
+  });

--- a/src/commands/monitor.ts
+++ b/src/commands/monitor.ts
@@ -1,0 +1,54 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { subDays } from 'date-fns';
+import { getConfig } from '../lib/config.js';
+import { getEngrams } from '../db/engram-queries.js';
+import { closeEngramsDb } from '../db/engrams.js';
+
+export const monitorCommand = new Command('monitor')
+  .description('Show what got promoted to memory vs. dropped')
+  .option('--days <n>', 'Days to look back', '7')
+  .action((opts: { days: string }) => {
+    const config = getConfig();
+    const cortex = config.cortex?.active;
+
+    if (!cortex) {
+      console.error(chalk.red('No active cortex. Run: think cortex switch <name>'));
+      process.exit(1);
+    }
+
+    const days = parseInt(opts.days, 10);
+    const since = subDays(new Date(), days);
+    const engrams = getEngrams(cortex, { since });
+
+    if (engrams.length === 0) {
+      console.log(chalk.dim(`No engrams in the last ${days} days.`));
+      closeEngramsDb(cortex);
+      return;
+    }
+
+    let promoted = 0;
+    let dropped = 0;
+    let pending = 0;
+
+    for (const e of engrams) {
+      const ts = e.created_at.slice(0, 16).replace('T', ' ');
+      const content = e.content.length > 80 ? e.content.slice(0, 77) + '...' : e.content;
+
+      if (e.promoted === null) {
+        console.log(`${chalk.yellow('?')} ${chalk.gray(ts)}  ${content}`);
+        pending++;
+      } else if (e.promoted === 1) {
+        console.log(`${chalk.green('✓')} ${chalk.gray(ts)}  ${content}`);
+        promoted++;
+      } else {
+        console.log(`${chalk.dim('✗')} ${chalk.gray(ts)}  ${chalk.dim(content)}`);
+        dropped++;
+      }
+    }
+
+    console.log();
+    console.log(`${engrams.length} total: ${chalk.green(`${promoted} promoted`)}, ${chalk.dim(`${dropped} dropped`)}, ${chalk.yellow(`${pending} pending`)}`);
+
+    closeEngramsDb(cortex);
+  });

--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -1,0 +1,46 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { getConfig } from '../lib/config.js';
+import { ensureRepoCloned, fetchBranch, readFileFromBranch, branchExists } from '../lib/git.js';
+import { parseMemoriesJsonl } from '../lib/curator.js';
+
+export const pullCommand = new Command('pull')
+  .argument('<cortex>', 'Cortex branch to pull memories from')
+  .description("Pull another cortex's memories (read-only)")
+  .option('--days <n>', 'Days of memories to include', '14')
+  .action(async (cortex: string, opts: { days: string }) => {
+    const config = getConfig();
+
+    if (!config.cortex?.repo) {
+      console.error(chalk.red('No cortex repo configured. Run: think cortex setup'));
+      process.exit(1);
+    }
+
+    ensureRepoCloned();
+
+    if (!branchExists(cortex)) {
+      console.error(chalk.red(`Cortex '${cortex}' does not exist.`));
+      process.exit(1);
+    }
+
+    fetchBranch(cortex);
+
+    const memoriesRaw = readFileFromBranch(cortex, 'memories.jsonl') ?? '';
+    const allMemories = parseMemoriesJsonl(memoriesRaw);
+
+    const days = parseInt(opts.days, 10);
+    const cutoff = new Date(Date.now() - days * 86400000).toISOString();
+    const recentMemories = allMemories.filter(m => m.ts >= cutoff);
+
+    if (recentMemories.length === 0) {
+      console.log(chalk.dim(`No memories in ${cortex} from the last ${days} days.`));
+      return;
+    }
+
+    console.log(chalk.cyan(`${cortex} memories (last ${days} days):`));
+    for (const m of recentMemories) {
+      const ts = m.ts.slice(0, 16).replace('T', ' ');
+      console.log(`  ${chalk.gray(ts)} ${chalk.dim(m.author + ':')} ${m.content}`);
+    }
+    console.log(chalk.dim(`\n${recentMemories.length} memories`));
+  });

--- a/src/commands/recall.ts
+++ b/src/commands/recall.ts
@@ -1,0 +1,76 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import fs from 'node:fs';
+import { getConfig } from '../lib/config.js';
+import { ensureRepoCloned, fetchBranch, readFileFromBranch } from '../lib/git.js';
+import { searchEngrams } from '../db/engram-queries.js';
+import { closeEngramsDb } from '../db/engrams.js';
+import { parseMemoriesJsonl } from '../lib/curator.js';
+import { getLongtermPath } from '../lib/paths.js';
+
+export const recallCommand = new Command('recall')
+  .argument('<query>', 'What to recall')
+  .description('Search memories from the cortex branch + local engrams')
+  .option('--days <n>', 'Days of memories to include', '14')
+  .action(async (query: string, opts: { days: string }) => {
+    const config = getConfig();
+    const cortex = config.cortex?.active;
+
+    if (!cortex) {
+      console.error(chalk.red('No active cortex. Run: think cortex switch <name>'));
+      process.exit(1);
+    }
+
+    ensureRepoCloned();
+    fetchBranch(cortex);
+
+    // Read memories from branch
+    const memoriesRaw = readFileFromBranch(cortex, 'memories.jsonl') ?? '';
+    const allMemories = parseMemoriesJsonl(memoriesRaw);
+
+    // Filter to recent window
+    const days = parseInt(opts.days, 10);
+    const cutoff = new Date(Date.now() - days * 86400000).toISOString();
+    const recentMemories = allMemories.filter(m => m.ts >= cutoff);
+
+    // Search local engrams
+    const matchingEngrams = searchEngrams(cortex, query);
+
+    // Read long-term summary if present
+    const ltPath = getLongtermPath(cortex);
+    const longterm = fs.existsSync(ltPath) ? fs.readFileSync(ltPath, 'utf-8').trim() : null;
+
+    // Output
+    if (recentMemories.length > 0) {
+      console.log(chalk.cyan(`Team memories (last ${days} days):`));
+      for (const m of recentMemories) {
+        const ts = m.ts.slice(0, 16).replace('T', ' ');
+        console.log(`  ${chalk.gray(ts)} ${chalk.dim(m.author + ':')} ${m.content}`);
+      }
+      console.log();
+    } else {
+      console.log(chalk.dim('No recent memories.'));
+      console.log();
+    }
+
+    if (longterm) {
+      console.log(chalk.cyan('Long-term context:'));
+      console.log(`  ${longterm}`);
+      console.log();
+    }
+
+    if (matchingEngrams.length > 0) {
+      console.log(chalk.cyan(`Matching engrams (local):`));
+      for (const e of matchingEngrams) {
+        const ts = e.created_at.slice(0, 16).replace('T', ' ');
+        console.log(`  ${chalk.gray(ts)} ${e.content}`);
+      }
+      console.log();
+    }
+
+    if (recentMemories.length === 0 && matchingEngrams.length === 0 && !longterm) {
+      console.log(chalk.dim('No results found.'));
+    }
+
+    closeEngramsDb(cortex);
+  });

--- a/src/db/engram-queries.ts
+++ b/src/db/engram-queries.ts
@@ -1,0 +1,94 @@
+import { v7 as uuidv7 } from 'uuid';
+import { getEngramsDb } from './engrams.js';
+
+export interface Engram {
+  id: string;
+  content: string;
+  created_at: string;
+  expires_at: string;
+  evaluated_at: string | null;
+  promoted: number | null;
+  deleted_at: string | null;
+}
+
+export interface InsertEngramParams {
+  content: string;
+  expiresInDays?: number;
+}
+
+export function insertEngram(cortexName: string, params: InsertEngramParams): Engram {
+  const db = getEngramsDb(cortexName);
+  const id = uuidv7();
+  const now = new Date();
+  const created_at = now.toISOString();
+  const expiresInDays = params.expiresInDays ?? 60;
+  const expires_at = new Date(now.getTime() + expiresInDays * 86400000).toISOString();
+
+  db.prepare(
+    `INSERT INTO engrams (id, content, created_at, expires_at) VALUES (?, ?, ?, ?)`
+  ).run(id, params.content, created_at, expires_at);
+
+  return { id, content: params.content, created_at, expires_at, evaluated_at: null, promoted: null, deleted_at: null };
+}
+
+export function getPendingEngrams(cortexName: string): Engram[] {
+  const db = getEngramsDb(cortexName);
+  return db.prepare(
+    `SELECT * FROM engrams WHERE evaluated_at IS NULL AND deleted_at IS NULL AND expires_at > ? ORDER BY created_at ASC`
+  ).all(new Date().toISOString()) as unknown as Engram[];
+}
+
+export function getEngrams(cortexName: string, params: { since?: Date; limit?: number }): Engram[] {
+  const db = getEngramsDb(cortexName);
+  const conditions = ['deleted_at IS NULL'];
+  const values: string[] = [];
+
+  if (params.since) {
+    conditions.push('created_at >= ?');
+    values.push(params.since.toISOString());
+  }
+
+  const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+  const limit = params.limit ?? 1000;
+
+  return db.prepare(
+    `SELECT * FROM engrams ${where} ORDER BY created_at DESC LIMIT ?`
+  ).all(...values, limit) as unknown as Engram[];
+}
+
+export function markEvaluated(cortexName: string, ids: string[], promoted: boolean): void {
+  const db = getEngramsDb(cortexName);
+  const now = new Date().toISOString();
+  const promotedVal = promoted ? 1 : 0;
+  const stmt = db.prepare(
+    `UPDATE engrams SET evaluated_at = ?, promoted = ? WHERE id = ?`
+  );
+
+  for (const id of ids) {
+    stmt.run(now, promotedVal, id);
+  }
+}
+
+export function pruneExpiredEngrams(cortexName: string): number {
+  const db = getEngramsDb(cortexName);
+  const result = db.prepare(
+    `DELETE FROM engrams WHERE expires_at < ? AND evaluated_at IS NOT NULL`
+  ).run(new Date().toISOString());
+  return Number(result.changes);
+}
+
+export function searchEngrams(cortexName: string, query: string, limit: number = 20): Engram[] {
+  const db = getEngramsDb(cortexName);
+  try {
+    return db.prepare(
+      `SELECT e.* FROM engrams e JOIN engrams_fts f ON e.rowid = f.rowid
+       WHERE engrams_fts MATCH ? AND e.deleted_at IS NULL
+       ORDER BY rank LIMIT ?`
+    ).all(query, limit) as unknown as Engram[];
+  } catch {
+    // FTS match syntax can fail on certain inputs — fall back to LIKE
+    return db.prepare(
+      `SELECT * FROM engrams WHERE content LIKE ? AND deleted_at IS NULL ORDER BY created_at DESC LIMIT ?`
+    ).all(`%${query}%`, limit) as unknown as Engram[];
+  }
+}

--- a/src/db/engram-queries.ts
+++ b/src/db/engram-queries.ts
@@ -86,9 +86,10 @@ export function searchEngrams(cortexName: string, query: string, limit: number =
        ORDER BY rank LIMIT ?`
     ).all(query, limit) as unknown as Engram[];
   } catch {
-    // FTS match syntax can fail on certain inputs — fall back to LIKE
+    // FTS match syntax can fail on certain inputs — fall back to LIKE with parameterized bind
+    const pattern = `%${query.replace(/%/g, '\\%').replace(/_/g, '\\_')}%`;
     return db.prepare(
-      `SELECT * FROM engrams WHERE content LIKE ? AND deleted_at IS NULL ORDER BY created_at DESC LIMIT ?`
-    ).all(`%${query}%`, limit) as unknown as Engram[];
+      `SELECT * FROM engrams WHERE content LIKE ? ESCAPE '\\' AND deleted_at IS NULL ORDER BY created_at DESC LIMIT ?`
+    ).all(pattern, limit) as unknown as Engram[];
   }
 }

--- a/src/db/engrams.ts
+++ b/src/db/engrams.ts
@@ -1,0 +1,69 @@
+import fs from 'node:fs';
+import { DatabaseSync } from 'node:sqlite';
+import { getEngramDbPath, ensureThinkDirs } from '../lib/paths.js';
+
+const dbs = new Map<string, DatabaseSync>();
+
+function ensureEngramSchema(db: DatabaseSync): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS engrams (
+      id TEXT PRIMARY KEY NOT NULL,
+      content TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      expires_at TEXT NOT NULL,
+      evaluated_at TEXT,
+      promoted INTEGER,
+      deleted_at TEXT
+    ) STRICT;
+  `);
+
+  db.exec(`
+    CREATE VIRTUAL TABLE IF NOT EXISTS engrams_fts
+      USING fts5(content, content='engrams', content_rowid='rowid');
+  `);
+
+  // Triggers to keep FTS in sync
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS engrams_ai AFTER INSERT ON engrams BEGIN
+      INSERT INTO engrams_fts(rowid, content) VALUES (new.rowid, new.content);
+    END;
+  `);
+
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS engrams_ad AFTER DELETE ON engrams BEGIN
+      INSERT INTO engrams_fts(engrams_fts, rowid, content) VALUES ('delete', old.rowid, old.content);
+    END;
+  `);
+}
+
+export function getEngramsDb(cortexName: string): DatabaseSync {
+  const cached = dbs.get(cortexName);
+  if (cached) return cached;
+
+  ensureThinkDirs();
+
+  const dbPath = getEngramDbPath(cortexName);
+  const db = new DatabaseSync(dbPath);
+  db.exec('PRAGMA journal_mode = WAL');
+  db.exec('PRAGMA synchronous = NORMAL');
+
+  ensureEngramSchema(db);
+
+  dbs.set(cortexName, db);
+  return db;
+}
+
+export function closeEngramsDb(cortexName: string): void {
+  const db = dbs.get(cortexName);
+  if (db) {
+    db.close();
+    dbs.delete(cortexName);
+  }
+}
+
+export function closeAllEngramsDbs(): void {
+  for (const [name, db] of dbs) {
+    db.close();
+    dbs.delete(name);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,13 +7,21 @@ import { exportCommand } from './commands/export.js';
 import { importCommand } from './commands/import.js';
 import { initCommand } from './commands/init.js';
 import { auditCommand } from './commands/audit.js';
+import { cortexCommand } from './commands/cortex.js';
+import { curateCommand } from './commands/curate.js';
+import { monitorCommand } from './commands/monitor.js';
+import { recallCommand } from './commands/recall.js';
+import { memoryCommand } from './commands/memory.js';
+import { curatorCommand } from './commands/curator-cmd.js';
+import { pullCommand } from './commands/pull.js';
 
 const program = new Command();
 
 program
   .name('think')
-  .description('Local-first CLI tool for capturing notes, work logs, and ideas with P2P sync')
-  .version('0.1.0');
+  .description('Local-first CLI tool for capturing notes, work logs, and ideas')
+  .version('0.1.0')
+  .option('-C, --cortex <name>', 'Use a specific cortex for this command');
 
 program.addCommand(logCommand);
 program.addCommand(syncCommand);
@@ -24,5 +32,12 @@ program.addCommand(exportCommand);
 program.addCommand(importCommand);
 program.addCommand(initCommand);
 program.addCommand(auditCommand);
+program.addCommand(cortexCommand);
+program.addCommand(curateCommand);
+program.addCommand(monitorCommand);
+program.addCommand(recallCommand);
+program.addCommand(memoryCommand);
+program.addCommand(curatorCommand);
+program.addCommand(pullCommand);
 
 program.parse();

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -2,10 +2,17 @@ import path from 'node:path';
 import fs from 'node:fs';
 import { v4 as uuidv4 } from 'uuid';
 
+export interface CortexConfig {
+  repo: string;
+  active?: string;
+  author: string;
+}
+
 export interface Config {
   peerId: string;
   syncPort: number;
   anthropicApiKey?: string;
+  cortex?: CortexConfig;
 }
 
 export function getConfigDir(): string {

--- a/src/lib/curator.ts
+++ b/src/lib/curator.ts
@@ -1,0 +1,134 @@
+import fs from 'node:fs';
+import { query } from '@anthropic-ai/claude-agent-sdk';
+import { getCuratorMdPath } from './paths.js';
+import type { Engram } from '../db/engram-queries.js';
+
+export interface MemoryEntry {
+  ts: string;
+  author: string;
+  content: string;
+  source_ids: string[];
+}
+
+const BASE_CURATION_PROMPT = `You are a memory curator. You evaluate recent work events and decide which ones are significant enough to become shared team memory.
+
+## What the team already knows
+{existing_memories}
+
+## What this contributor considers worth sharing
+{curator_md}
+
+## Recent work events to evaluate
+{pending_engrams}
+
+---
+
+Your task:
+
+1. Read what the team already knows to avoid redundancy.
+2. Read the contributor's guidance (if provided) for their priorities.
+3. For each event, decide: is this something the team should remember?
+   Look for:
+   - Completed work, shipped deliverables, merged code
+   - Decisions made, direction changes, pivots
+   - Blockers encountered or resolved
+   - Clusters — multiple events around the same topic signal importance
+   - Weight — urgency, frustration, or surprise in the language suggests significance
+4. Routine, administrative, or low-signal events should be dropped.
+   Dropping is correct, not a failure.
+
+Output format — return a JSON array of entries to append:
+[
+  {
+    "ts": "ISO 8601 timestamp",
+    "author": "contributor name",
+    "content": "the memory — specific, factual, written for an agent",
+    "source_ids": ["id1", "id2"]
+  }
+]
+
+If nothing warrants a new entry, return an empty array: []
+
+Rules:
+- Write for an agent that will read this as context before starting work
+- Be specific: names, projects, decisions, status — not generalizations
+- Each entry should be 1-3 sentences
+- Do not reference this process or explain your reasoning
+- Do not include PII, HR matters, compensation, or client-confidential details
+- Do not repeat information already in the team's memory
+- Only add an entry if there is genuinely new information`;
+
+export function readCuratorMd(): string | null {
+  const mdPath = getCuratorMdPath();
+  if (fs.existsSync(mdPath)) {
+    return fs.readFileSync(mdPath, 'utf-8').trim();
+  }
+  return null;
+}
+
+export function assembleCurationPrompt(params: {
+  existingMemories: MemoryEntry[];
+  curatorMd: string | null;
+  pendingEngrams: Engram[];
+  author: string;
+}): string {
+  const memoriesText = params.existingMemories.length > 0
+    ? params.existingMemories
+        .map(m => `- [${m.ts}] ${m.author}: ${m.content}`)
+        .join('\n')
+    : '(no memories yet)';
+
+  const curatorMdText = params.curatorMd ?? '(none provided)';
+
+  const engramsText = params.pendingEngrams
+    .map(e => `- [${e.created_at}] (id: ${e.id}) ${e.content}`)
+    .join('\n');
+
+  return BASE_CURATION_PROMPT
+    .replace('{existing_memories}', memoriesText)
+    .replace('{curator_md}', curatorMdText)
+    .replace('{pending_engrams}', engramsText);
+}
+
+export function parseMemoriesJsonl(content: string): MemoryEntry[] {
+  if (!content.trim()) return [];
+  return content.trim().split('\n')
+    .filter(Boolean)
+    .map(line => JSON.parse(line) as MemoryEntry);
+}
+
+export async function runCuration(prompt: string): Promise<MemoryEntry[]> {
+  let result = '';
+
+  for await (const message of query({
+    prompt,
+    options: {
+      systemPrompt: 'You are a memory curator. Respond only with a valid JSON array. No markdown, no code fences, no explanation.',
+      tools: [],
+      model: 'claude-sonnet-4-6',
+      persistSession: false,
+    },
+  })) {
+    if ('result' in message && typeof message.result === 'string') {
+      result = message.result;
+    }
+  }
+
+  if (!result) {
+    throw new Error('No result returned from curation');
+  }
+
+  // Strip markdown code fences if present
+  let cleaned = result.trim();
+  if (cleaned.startsWith('```')) {
+    cleaned = cleaned.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '');
+  }
+
+  const entries = JSON.parse(cleaned) as MemoryEntry[];
+
+  if (!Array.isArray(entries)) {
+    throw new Error('Curation returned non-array response');
+  }
+
+  return entries;
+}

--- a/src/lib/curator.ts
+++ b/src/lib/curator.ts
@@ -92,9 +92,24 @@ export function assembleCurationPrompt(params: {
 
 export function parseMemoriesJsonl(content: string): MemoryEntry[] {
   if (!content.trim()) return [];
-  return content.trim().split('\n')
-    .filter(Boolean)
-    .map(line => JSON.parse(line) as MemoryEntry);
+  const entries: MemoryEntry[] = [];
+  for (const line of content.trim().split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      const parsed = JSON.parse(line);
+      if (parsed && typeof parsed.content === 'string') {
+        entries.push({
+          ts: parsed.ts ?? '',
+          author: parsed.author ?? 'unknown',
+          content: parsed.content,
+          source_ids: Array.isArray(parsed.source_ids) ? parsed.source_ids : [],
+        });
+      }
+    } catch {
+      // Skip malformed lines — don't crash on corrupted JSONL
+    }
+  }
+  return entries;
 }
 
 export async function runCuration(prompt: string): Promise<MemoryEntry[]> {
@@ -124,11 +139,28 @@ export async function runCuration(prompt: string): Promise<MemoryEntry[]> {
     cleaned = cleaned.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '');
   }
 
-  const entries = JSON.parse(cleaned) as MemoryEntry[];
+  const raw = JSON.parse(cleaned);
 
-  if (!Array.isArray(entries)) {
+  if (!Array.isArray(raw)) {
     throw new Error('Curation returned non-array response');
   }
+
+  // Validate and normalize each entry
+  const entries: MemoryEntry[] = raw.map((item: unknown, i: number) => {
+    if (!item || typeof item !== 'object') {
+      throw new Error(`Curation entry ${i} is not an object`);
+    }
+    const obj = item as Record<string, unknown>;
+    if (typeof obj.content !== 'string' || !obj.content) {
+      throw new Error(`Curation entry ${i} is missing content`);
+    }
+    return {
+      ts: typeof obj.ts === 'string' ? obj.ts : new Date().toISOString(),
+      author: typeof obj.author === 'string' ? obj.author : 'unknown',
+      content: obj.content,
+      source_ids: Array.isArray(obj.source_ids) ? obj.source_ids.filter((id): id is string => typeof id === 'string') : [],
+    };
+  });
 
   return entries;
 }

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -1,0 +1,125 @@
+import { execFileSync, execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { getRepoPath } from './paths.js';
+import { getConfig } from './config.js';
+
+function runGit(args: string[], cwd?: string): string {
+  const repoPath = cwd ?? getRepoPath();
+  return execFileSync('git', args, {
+    cwd: repoPath,
+    encoding: 'utf-8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  }).trim();
+}
+
+export function ensureRepoCloned(): void {
+  const config = getConfig();
+  if (!config.cortex?.repo) {
+    throw new Error('No cortex repo configured. Run: think cortex setup');
+  }
+
+  const repoPath = getRepoPath();
+
+  if (fs.existsSync(path.join(repoPath, '.git'))) {
+    const remote = runGit(['remote', 'get-url', 'origin'], repoPath);
+    if (remote !== config.cortex.repo) {
+      throw new Error(`Repo at ${repoPath} points to ${remote}, expected ${config.cortex.repo}`);
+    }
+    return;
+  }
+
+  fs.mkdirSync(repoPath, { recursive: true });
+  execFileSync('git', ['clone', '--no-checkout', config.cortex.repo, repoPath], {
+    encoding: 'utf-8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+}
+
+export function branchExists(branchName: string): boolean {
+  try {
+    runGit(['ls-remote', '--exit-code', '--heads', 'origin', branchName]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function createOrphanBranch(branchName: string): void {
+  runGit(['checkout', '--orphan', branchName]);
+  try {
+    runGit(['rm', '-rf', '.']);
+  } catch {
+    // Empty repo — nothing to remove
+  }
+
+  const repoPath = getRepoPath();
+  fs.writeFileSync(path.join(repoPath, 'memories.jsonl'), '', 'utf-8');
+  runGit(['add', 'memories.jsonl']);
+  runGit(['commit', '-m', `init: create cortex ${branchName}`]);
+  runGit(['push', '--set-upstream', 'origin', branchName]);
+}
+
+export function fetchBranch(branchName: string): void {
+  runGit(['fetch', 'origin', branchName]);
+}
+
+export function readFileFromBranch(branchName: string, filePath: string): string | null {
+  try {
+    return runGit(['show', `origin/${branchName}:${filePath}`]);
+  } catch {
+    return null;
+  }
+}
+
+export function appendAndCommit(
+  branchName: string,
+  newLines: string[],
+  commitMessage: string,
+  maxRetries: number = 3,
+): void {
+  const repoPath = getRepoPath();
+  const memoriesPath = path.join(repoPath, 'memories.jsonl');
+
+  try {
+    runGit(['switch', branchName]);
+  } catch {
+    runGit(['switch', '-c', branchName, `origin/${branchName}`]);
+  }
+
+  try {
+    runGit(['pull', '--rebase', 'origin', branchName]);
+  } catch {
+    // May fail if nothing to pull yet
+  }
+
+  const content = newLines.join('\n') + '\n';
+  fs.appendFileSync(memoriesPath, content, 'utf-8');
+
+  runGit(['add', 'memories.jsonl']);
+  runGit(['commit', '-m', commitMessage]);
+
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      runGit(['push', 'origin', branchName]);
+      return;
+    } catch {
+      if (attempt === maxRetries) {
+        throw new Error(`Push failed after ${maxRetries} attempts. Run 'think curate' again.`);
+      }
+      runGit(['pull', '--rebase', 'origin', branchName]);
+    }
+  }
+}
+
+export function getFileLog(branchName: string, filePath: string): string {
+  return runGit(['log', '--oneline', `origin/${branchName}`, '--', filePath]);
+}
+
+export function listRemoteBranches(): string[] {
+  const output = runGit(['ls-remote', '--heads', 'origin']);
+  return output.trim().split('\n')
+    .filter(Boolean)
+    .map(line => line.split('\t')[1]?.replace('refs/heads/', ''))
+    .filter(Boolean) as string[];
+}

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -89,8 +89,14 @@ export function appendAndCommit(
 
   try {
     runGit(['pull', '--rebase', 'origin', branchName]);
-  } catch {
-    // May fail if nothing to pull yet
+  } catch (err) {
+    // Acceptable: fails when local branch has no upstream yet (first push)
+    // Not acceptable: rebase conflict — abort and surface the error
+    const message = err instanceof Error ? err.message : String(err);
+    if (message.includes('CONFLICT') || message.includes('could not apply')) {
+      try { runGit(['rebase', '--abort']); } catch { /* best effort */ }
+      throw new Error(`Rebase conflict on ${branchName}. This should not happen with append-only files — check for manual edits to memories.jsonl.`);
+    }
   }
 
   const content = newLines.join('\n') + '\n';

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -1,8 +1,23 @@
 import path from 'node:path';
 import fs from 'node:fs';
 
+function getHome(): string {
+  const home = process.env.HOME;
+  if (!home) {
+    throw new Error('HOME environment variable is not set');
+  }
+  return home;
+}
+
+function sanitizeName(name: string): string {
+  if (!name || /[\/\\\.]{2}/.test(name) || /[^a-zA-Z0-9_-]/.test(name)) {
+    throw new Error(`Invalid cortex name: "${name}". Use only alphanumeric characters, hyphens, and underscores.`);
+  }
+  return name;
+}
+
 export function getThinkDir(): string {
-  return path.join(process.env.HOME!, '.think');
+  return path.join(getHome(), '.think');
 }
 
 export function getEngramsDir(): string {
@@ -10,7 +25,7 @@ export function getEngramsDir(): string {
 }
 
 export function getEngramDbPath(cortexName: string): string {
-  return path.join(getEngramsDir(), `${cortexName}.db`);
+  return path.join(getEngramsDir(), `${sanitizeName(cortexName)}.db`);
 }
 
 export function getRepoPath(): string {
@@ -22,7 +37,7 @@ export function getLongtermDir(): string {
 }
 
 export function getLongtermPath(cortexName: string): string {
-  return path.join(getLongtermDir(), `${cortexName}.md`);
+  return path.join(getLongtermDir(), `${sanitizeName(cortexName)}.md`);
 }
 
 export function getCuratorMdPath(): string {

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -1,0 +1,35 @@
+import path from 'node:path';
+import fs from 'node:fs';
+
+export function getThinkDir(): string {
+  return path.join(process.env.HOME!, '.think');
+}
+
+export function getEngramsDir(): string {
+  return path.join(getThinkDir(), 'engrams');
+}
+
+export function getEngramDbPath(cortexName: string): string {
+  return path.join(getEngramsDir(), `${cortexName}.db`);
+}
+
+export function getRepoPath(): string {
+  return path.join(getThinkDir(), 'repo');
+}
+
+export function getLongtermDir(): string {
+  return path.join(getThinkDir(), 'longterm');
+}
+
+export function getLongtermPath(cortexName: string): string {
+  return path.join(getLongtermDir(), `${cortexName}.md`);
+}
+
+export function getCuratorMdPath(): string {
+  return path.join(getThinkDir(), 'curator.md');
+}
+
+export function ensureThinkDirs(): void {
+  fs.mkdirSync(getEngramsDir(), { recursive: true });
+  fs.mkdirSync(getLongtermDir(), { recursive: true });
+}


### PR DESCRIPTION
## Summary
- Adds cortex commands (`think cortex setup/create/list/switch/current`) for managing team memory workspaces as git branches
- Implements full curation loop: `think curate` evaluates local engrams via Claude, appends curated memories as JSONL to the cortex branch, commits and pushes
- `think sync` is now cortex-aware — routes to per-cortex engram DB when active, falls back to original `think.db` when no cortex configured
- New commands: `monitor`, `recall`, `memory`, `curator edit/show`, `pull`
- Per-cortex SQLite with FTS5 for engram storage and search
- Git operations with rebase/retry for concurrent push handling
- Two-layer curator prompt: base (ships with product, privacy guardrails) + user (`~/.think/curator.md`)

## Test plan
- [ ] `think cortex setup <repo-url>` — clones repo, stores config
- [ ] `think cortex create engineering` — creates orphan branch with empty `memories.jsonl`
- [ ] `think sync "test"` — writes to `~/.think/engrams/engineering.db`, prints `[engineering]` badge
- [ ] `think curate --dry-run` — previews curation without pushing
- [ ] `think curate` — full loop: evaluate → curate → append JSONL → commit → push
- [ ] `think monitor` — shows promoted/dropped/pending engrams
- [ ] `think recall "query"` — returns memories from branch + FTS on local engrams
- [ ] `think memory` — pretty-prints memories from branch
- [ ] `think memory --history` — shows git log of curation commits
- [ ] `think list` (no cortex) — still works with old `think.db`, unchanged
- [ ] `think summary --raw` — still works, unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)