### PR TITLE
Add think pause/resume for suppressing engram creation

### DIFF
--- a/src/commands/log.ts
+++ b/src/commands/log.ts
@@ -44,6 +44,12 @@ export const syncCommand = new Command('sync')
   .action(function (this: Command, message: string, opts: { source: string; tags?: string; silent?: boolean }) {
     const globalOpts = this.optsWithGlobals() as { cortex?: string };
     const config = getConfig();
+
+    if (config.paused) {
+      // Silently skip — don't break CLAUDE.md auto-logging
+      return;
+    }
+
     const cortex = globalOpts.cortex ?? config.cortex?.active;
 
     if (cortex) {

--- a/src/commands/pause.ts
+++ b/src/commands/pause.ts
@@ -1,0 +1,21 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { getConfig, saveConfig } from '../lib/config.js';
+
+export const pauseCommand = new Command('pause')
+  .description('Pause engram creation — think sync will silently skip until resumed')
+  .action(() => {
+    const config = getConfig();
+    config.paused = true;
+    saveConfig(config);
+    console.log(chalk.yellow('⏸') + ' Engram creation paused. Run ' + chalk.dim('think resume') + ' to re-enable.');
+  });
+
+export const resumeCommand = new Command('resume')
+  .description('Resume engram creation after a pause')
+  .action(() => {
+    const config = getConfig();
+    config.paused = false;
+    saveConfig(config);
+    console.log(chalk.green('✓') + ' Engram creation resumed.');
+  });

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import { recallCommand } from './commands/recall.js';
 import { memoryCommand } from './commands/memory.js';
 import { curatorCommand } from './commands/curator-cmd.js';
 import { pullCommand } from './commands/pull.js';
+import { pauseCommand, resumeCommand } from './commands/pause.js';
 
 const program = new Command();
 
@@ -39,5 +40,7 @@ program.addCommand(recallCommand);
 program.addCommand(memoryCommand);
 program.addCommand(curatorCommand);
 program.addCommand(pullCommand);
+program.addCommand(pauseCommand);
+program.addCommand(resumeCommand);
 
 program.parse();

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -13,6 +13,7 @@ export interface Config {
   syncPort: number;
   anthropicApiKey?: string;
   cortex?: CortexConfig;
+  paused?: boolean;
 }
 
 export function getConfigDir(): string {


### PR DESCRIPTION
## Summary
- `think pause` — sets a paused flag, `think sync` silently no-ops while active
- `think resume` — re-enables engram creation
- Silent skip ensures CLAUDE.md auto-logging doesn't produce errors during sensitive work

## Test plan
- [ ] `think pause` — prints paused message
- [ ] `think sync "test"` while paused — no output, no engram written
- [ ] `think resume` — prints resumed message
- [ ] `think sync "test"` after resume — works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)