### PR TITLE
Add curation frequency, confirm-before-commit, and config command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "think",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "think",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.98",
         "chalk": "^5.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-think",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "description": "Local-first CLI that gives AI agents persistent, curated memory",
   "bin": {

--- a/src/commands/config-cmd.ts
+++ b/src/commands/config-cmd.ts
@@ -1,0 +1,43 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { getConfig, saveConfig } from '../lib/config.js';
+
+export const configCommand = new Command('config')
+  .description('View or update think configuration');
+
+configCommand.addCommand(new Command('show')
+  .description('Print current configuration')
+  .action(() => {
+    const config = getConfig();
+    console.log(JSON.stringify(config, null, 2));
+  }));
+
+configCommand.addCommand(new Command('set')
+  .argument('<key>', 'Config key (e.g., cortex.curateEveryN, cortex.confirmBeforeCommit)')
+  .argument('<value>', 'Value to set')
+  .description('Set a configuration value')
+  .action((key: string, value: string) => {
+    const config = getConfig();
+
+    // Parse value
+    let parsed: unknown = value;
+    if (value === 'true') parsed = true;
+    else if (value === 'false') parsed = false;
+    else if (/^\d+$/.test(value)) parsed = parseInt(value, 10);
+
+    // Set nested keys
+    const parts = key.split('.');
+    let target: Record<string, unknown> = config as Record<string, unknown>;
+
+    for (let i = 0; i < parts.length - 1; i++) {
+      if (!target[parts[i]] || typeof target[parts[i]] !== 'object') {
+        target[parts[i]] = {};
+      }
+      target = target[parts[i]] as Record<string, unknown>;
+    }
+
+    target[parts[parts.length - 1]] = parsed;
+    saveConfig(config);
+
+    console.log(chalk.green('✓') + ` ${key} = ${JSON.stringify(parsed)}`);
+  }));

--- a/src/commands/config-cmd.ts
+++ b/src/commands/config-cmd.ts
@@ -2,6 +2,15 @@ import { Command } from 'commander';
 import chalk from 'chalk';
 import { getConfig, saveConfig } from '../lib/config.js';
 
+const ALLOWED_KEYS = new Set([
+  'cortex.curateEveryN',
+  'cortex.confirmBeforeCommit',
+  'cortex.author',
+  'cortex.repo',
+  'cortex.active',
+  'paused',
+]);
+
 export const configCommand = new Command('config')
   .description('View or update think configuration');
 
@@ -17,6 +26,12 @@ configCommand.addCommand(new Command('set')
   .argument('<value>', 'Value to set')
   .description('Set a configuration value')
   .action((key: string, value: string) => {
+    if (!ALLOWED_KEYS.has(key)) {
+      console.error(chalk.red(`Unknown config key: ${key}`));
+      console.error(chalk.dim(`Allowed keys: ${[...ALLOWED_KEYS].join(', ')}`));
+      process.exit(1);
+    }
+
     const config = getConfig();
 
     // Parse value

--- a/src/commands/curate.ts
+++ b/src/commands/curate.ts
@@ -1,4 +1,5 @@
 import { Command } from 'commander';
+import readline from 'node:readline';
 import chalk from 'chalk';
 import { getConfig } from '../lib/config.js';
 import { ensureRepoCloned, fetchBranch, readFileFromBranch, appendAndCommit } from '../lib/git.js';
@@ -99,7 +100,47 @@ export const curateCommand = new Command('curate')
       return;
     }
 
-    // 8. Append to memories.jsonl and push
+    // 8. Confirm before commit (if configured)
+    if (config.cortex?.confirmBeforeCommit && newEntries.length > 0) {
+      console.log();
+      console.log(chalk.cyan('Proposed memories:'));
+      for (let i = 0; i < newEntries.length; i++) {
+        console.log(chalk.green(`  ${i + 1}. `) + newEntries[i].content);
+      }
+      console.log();
+
+      const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+      const answer = await new Promise<string>((resolve) => {
+        rl.question('  Commit these memories? [Y/n/edit] ', (ans) => {
+          rl.close();
+          resolve(ans.trim().toLowerCase());
+        });
+      });
+
+      if (answer === 'n' || answer === 'no') {
+        console.log(chalk.dim('  Aborted. Engrams left as pending.'));
+        closeEngramsDb(cortex);
+        return;
+      }
+
+      if (answer === 'e' || answer === 'edit') {
+        // Let user edit each entry
+        for (let i = 0; i < newEntries.length; i++) {
+          const editRl = readline.createInterface({ input: process.stdin, output: process.stdout });
+          const edited = await new Promise<string>((resolve) => {
+            editRl.question(`  ${i + 1}. ${chalk.dim('(enter to keep, or type replacement)')}\n     ${newEntries[i].content}\n     > `, (ans) => {
+              editRl.close();
+              resolve(ans.trim());
+            });
+          });
+          if (edited) {
+            newEntries[i].content = edited;
+          }
+        }
+      }
+    }
+
+    // 9. Append to memories.jsonl and push
     if (newEntries.length > 0) {
       const newLines = newEntries.map(e => JSON.stringify(e));
       const commitMsg = `curate: ${author}, ${pending.length} engrams, ${newEntries.length} memories`;

--- a/src/commands/log.ts
+++ b/src/commands/log.ts
@@ -72,9 +72,11 @@ export const syncCommand = new Command('sync')
           if (!opts.silent) {
             console.log(chalk.dim(`  ${pending.length} pending engrams — triggering curation...`));
           }
+          // Close DB before spawning — the child process will open its own connection
+          // WAL mode ensures the child can read what we just wrote
           closeEngramsDb(cortex);
-          // Spawn curate as a detached background process so sync returns immediately
-          spawn('think', ['curate'], { detached: true, stdio: 'ignore' }).unref();
+          // Use process.execPath + process.argv[1] so it works regardless of how think was invoked
+          spawn(process.execPath, [process.argv[1], 'curate'], { detached: true, stdio: 'ignore' }).unref();
           return;
         }
       }

--- a/src/commands/log.ts
+++ b/src/commands/log.ts
@@ -1,9 +1,10 @@
 import { Command } from 'commander';
+import { spawn } from 'node:child_process';
 import chalk from 'chalk';
 import { insertEntry } from '../db/queries.js';
 import { closeDb } from '../db/client.js';
 import { getConfig } from '../lib/config.js';
-import { insertEngram } from '../db/engram-queries.js';
+import { insertEngram, getPendingEngrams } from '../db/engram-queries.js';
 import { closeEngramsDb } from '../db/engrams.js';
 
 export const logCommand = new Command('log')
@@ -61,6 +62,21 @@ export const syncCommand = new Command('sync')
         const ts = chalk.gray(engram.created_at.slice(0, 16).replace('T', ' '));
         console.log(`${chalk.green('✓')} ${badge} engram saved ${ts}`);
         console.log(`  ${engram.content}`);
+      }
+
+      // Auto-curate if threshold is set and reached
+      const curateEveryN = config.cortex?.curateEveryN;
+      if (curateEveryN && curateEveryN > 0) {
+        const pending = getPendingEngrams(cortex);
+        if (pending.length >= curateEveryN) {
+          if (!opts.silent) {
+            console.log(chalk.dim(`  ${pending.length} pending engrams — triggering curation...`));
+          }
+          closeEngramsDb(cortex);
+          // Spawn curate as a detached background process so sync returns immediately
+          spawn('think', ['curate'], { detached: true, stdio: 'ignore' }).unref();
+          return;
+        }
       }
 
       closeEngramsDb(cortex);

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { memoryCommand } from './commands/memory.js';
 import { curatorCommand } from './commands/curator-cmd.js';
 import { pullCommand } from './commands/pull.js';
 import { pauseCommand, resumeCommand } from './commands/pause.js';
+import { configCommand } from './commands/config-cmd.js';
 
 const program = new Command();
 
@@ -42,5 +43,6 @@ program.addCommand(curatorCommand);
 program.addCommand(pullCommand);
 program.addCommand(pauseCommand);
 program.addCommand(resumeCommand);
+program.addCommand(configCommand);
 
 program.parse();

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -6,6 +6,8 @@ export interface CortexConfig {
   repo: string;
   active?: string;
   author: string;
+  curateEveryN?: number;
+  confirmBeforeCommit?: boolean;
 }
 
 export interface Config {


### PR DESCRIPTION
## Summary
- `cortex.curateEveryN` — auto-triggers `think curate` in the background when pending engrams hit the threshold
- `cortex.confirmBeforeCommit` — curate shows proposed memories and prompts Y/n/edit before pushing
- `think config set <key> <value>` — set config values with dotted keys (e.g., `think config set cortex.curateEveryN 5`)
- `think config show` — print current config

## Test plan
- [ ] `think config set cortex.curateEveryN 3` — sets threshold
- [ ] `think sync` three times — third sync triggers background curation
- [ ] `think config set cortex.confirmBeforeCommit true` — enables confirmation
- [ ] `think curate` — shows proposed memories, prompts for Y/n/edit
- [ ] Enter `n` — aborts, engrams stay pending
- [ ] Enter `edit` — step through entries, type replacement or enter to keep
- [ ] `think config set cortex.confirmBeforeCommit false` — disables confirmation
- [ ] `think config show` — displays full config

🤖 Generated with [Claude Code](https://claude.com/claude-code)