### PR TITLE
Add update check and think update command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "think",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "think",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.98",
         "chalk": "^5.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-think",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "description": "Local-first CLI that gives AI agents persistent, curated memory",
   "bin": {

--- a/src/commands/log.ts
+++ b/src/commands/log.ts
@@ -6,6 +6,7 @@ import { closeDb } from '../db/client.js';
 import { getConfig } from '../lib/config.js';
 import { insertEngram, getPendingEngrams } from '../db/engram-queries.js';
 import { closeEngramsDb } from '../db/engrams.js';
+import { checkForUpdate } from '../lib/update-check.js';
 
 export const logCommand = new Command('log')
   .description('Log a note or entry')
@@ -103,5 +104,13 @@ export const syncCommand = new Command('sync')
       }
 
       closeDb();
+    }
+
+    // Non-blocking update check (cached, runs at most once per 24h)
+    if (!opts.silent) {
+      const updateMsg = checkForUpdate();
+      if (updateMsg) {
+        console.log(chalk.yellow(`  ℹ ${updateMsg}`));
+      }
     }
   });

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,0 +1,28 @@
+import { Command } from 'commander';
+import { execFileSync } from 'node:child_process';
+import chalk from 'chalk';
+
+export const updateCommand = new Command('update')
+  .description('Update think to the latest version')
+  .action(() => {
+    console.log(chalk.cyan('Checking for updates...'));
+
+    try {
+      const result = execFileSync('npm', ['install', '-g', 'open-think@latest'], {
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+
+      // Extract version from npm output
+      const match = result.match(/open-think@(\S+)/);
+      const version = match ? match[1] : 'latest';
+
+      console.log(chalk.green('✓') + ` Updated to open-think@${version}`);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(chalk.red('Update failed. Try manually: npm install -g open-think@latest'));
+      if (message.includes('EACCES')) {
+        console.error(chalk.dim('  You may need to run with sudo or fix npm permissions.'));
+      }
+    }
+  });

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { curatorCommand } from './commands/curator-cmd.js';
 import { pullCommand } from './commands/pull.js';
 import { pauseCommand, resumeCommand } from './commands/pause.js';
 import { configCommand } from './commands/config-cmd.js';
+import { updateCommand } from './commands/update.js';
 
 const program = new Command();
 
@@ -44,5 +45,6 @@ program.addCommand(pullCommand);
 program.addCommand(pauseCommand);
 program.addCommand(resumeCommand);
 program.addCommand(configCommand);
+program.addCommand(updateCommand);
 
 program.parse();

--- a/src/lib/update-check.ts
+++ b/src/lib/update-check.ts
@@ -1,0 +1,83 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFile } from 'node:child_process';
+import { getConfigDir } from './config.js';
+
+const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const PACKAGE_NAME = 'open-think';
+
+interface VersionCache {
+  latest: string;
+  checkedAt: number;
+}
+
+function cachePath(): string {
+  return path.join(getConfigDir(), 'version-cache.json');
+}
+
+function readCache(): VersionCache | null {
+  try {
+    const raw = fs.readFileSync(cachePath(), 'utf-8');
+    return JSON.parse(raw) as VersionCache;
+  } catch {
+    return null;
+  }
+}
+
+function writeCache(cache: VersionCache): void {
+  const dir = getConfigDir();
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(cachePath(), JSON.stringify(cache), 'utf-8');
+}
+
+function getInstalledVersion(): string | null {
+  try {
+    const pkgPath = path.join(import.meta.dirname, '..', 'package.json');
+    const raw = fs.readFileSync(pkgPath, 'utf-8');
+    return JSON.parse(raw).version ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function isNewer(latest: string, current: string): boolean {
+  const l = latest.split('.').map(Number);
+  const c = current.split('.').map(Number);
+  for (let i = 0; i < 3; i++) {
+    if ((l[i] ?? 0) > (c[i] ?? 0)) return true;
+    if ((l[i] ?? 0) < (c[i] ?? 0)) return false;
+  }
+  return false;
+}
+
+export function checkForUpdate(): string | null {
+  const installed = getInstalledVersion();
+  if (!installed) return null;
+
+  const cache = readCache();
+  const now = Date.now();
+
+  // Return cached result if fresh
+  if (cache && (now - cache.checkedAt) < CHECK_INTERVAL_MS) {
+    if (isNewer(cache.latest, installed)) {
+      return `open-think ${cache.latest} available (you have ${installed}). Run: npm update -g open-think`;
+    }
+    return null;
+  }
+
+  // Check in background — don't block the current command
+  execFile('npm', ['view', PACKAGE_NAME, 'version'], { timeout: 5000 }, (err, stdout) => {
+    if (err) return;
+    const latest = stdout.trim();
+    if (latest) {
+      writeCache({ latest, checkedAt: Date.now() });
+    }
+  });
+
+  // On first check, use cached value if available (stale but better than nothing)
+  if (cache && isNewer(cache.latest, installed)) {
+    return `open-think ${cache.latest} available (you have ${installed}). Run: npm update -g open-think`;
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- `think update` — runs `npm install -g open-think@latest` to update to the latest version
- Non-blocking version check on `think sync` — cached for 24h, shows a one-line notice when an update is available
- HiveDB setup script updated separately to append auto-update instruction to CLAUDE.md so agents run `think update` at session start

## Test plan
- [ ] `think update` — updates to latest npm version
- [ ] `think sync "test"` — first run triggers background version check (no notice yet)
- [ ] `think sync "test"` again — shows notice if npm has a newer version
- [ ] Notice does not appear when `--silent` is used

🤖 Generated with [Claude Code](https://claude.com/claude-code)