### PR TITLE
Add curation tuning: selectivity, granularity, maxMemoriesPerRun

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "think",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "think",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.98",
         "chalk": "^5.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-think",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "description": "Local-first CLI that gives AI agents persistent, curated memory",
   "bin": {

--- a/src/commands/config-cmd.ts
+++ b/src/commands/config-cmd.ts
@@ -5,6 +5,9 @@ import { getConfig, saveConfig } from '../lib/config.js';
 const ALLOWED_KEYS = new Set([
   'cortex.curateEveryN',
   'cortex.confirmBeforeCommit',
+  'cortex.selectivity',
+  'cortex.granularity',
+  'cortex.maxMemoriesPerRun',
   'cortex.author',
   'cortex.repo',
   'cortex.active',

--- a/src/commands/curate.ts
+++ b/src/commands/curate.ts
@@ -53,6 +53,9 @@ export const curateCommand = new Command('curate')
       curatorMd,
       pendingEngrams: pending,
       author,
+      selectivity: config.cortex?.selectivity,
+      granularity: config.cortex?.granularity,
+      maxMemoriesPerRun: config.cortex?.maxMemoriesPerRun,
     });
 
     let newEntries;

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -8,6 +8,9 @@ export interface CortexConfig {
   author: string;
   curateEveryN?: number;
   confirmBeforeCommit?: boolean;
+  selectivity?: 'low' | 'medium' | 'high';
+  granularity?: 'detailed' | 'summary';
+  maxMemoriesPerRun?: number;
 }
 
 export interface Config {

--- a/src/lib/curator.ts
+++ b/src/lib/curator.ts
@@ -71,6 +71,9 @@ export function assembleCurationPrompt(params: {
   curatorMd: string | null;
   pendingEngrams: Engram[];
   author: string;
+  selectivity?: 'low' | 'medium' | 'high';
+  granularity?: 'detailed' | 'summary';
+  maxMemoriesPerRun?: number;
 }): string {
   const memoriesText = params.existingMemories.length > 0
     ? params.existingMemories
@@ -84,10 +87,35 @@ export function assembleCurationPrompt(params: {
     .map(e => `- [${e.created_at}] (id: ${e.id}) ${e.content}`)
     .join('\n');
 
-  return BASE_CURATION_PROMPT
+  let prompt = BASE_CURATION_PROMPT
     .replace('{existing_memories}', memoriesText)
     .replace('{curator_md}', curatorMdText)
     .replace('{pending_engrams}', engramsText);
+
+  // Append tuning instructions based on config
+  const tuning: string[] = [];
+
+  if (params.selectivity === 'high') {
+    tuning.push('Be very selective. Only promote clearly significant events: major decisions, shipped deliverables, critical blockers, direction changes. Skip routine commits, minor fixes, and incremental progress.');
+  } else if (params.selectivity === 'low') {
+    tuning.push('Be inclusive. Promote most work events that have any team relevance. Only drop purely administrative or personal events.');
+  }
+
+  if (params.granularity === 'summary') {
+    tuning.push('Consolidate related events into single memory entries. Prefer fewer, broader memories over many specific ones.');
+  } else if (params.granularity === 'detailed') {
+    tuning.push('Keep memories specific and granular. Each distinct event or decision should be its own memory entry. Do not roll up multiple events into one.');
+  }
+
+  if (params.maxMemoriesPerRun && params.maxMemoriesPerRun > 0) {
+    tuning.push(`Produce at most ${params.maxMemoriesPerRun} memory entries from this batch. If more events are significant, prioritize the most important.`);
+  }
+
+  if (tuning.length > 0) {
+    prompt += '\n\nAdditional instructions:\n' + tuning.map(t => `- ${t}`).join('\n');
+  }
+
+  return prompt;
 }
 
 export function parseMemoriesJsonl(content: string): MemoryEntry[] {


### PR DESCRIPTION
## Summary
- `cortex.selectivity` (low/medium/high) — controls how strict the curator is about promotion
- `cortex.granularity` (detailed/summary) — controls whether memories stay per-event or get consolidated
- `cortex.maxMemoriesPerRun` — caps memory output per curation run
- All inject into the curation prompt as additional instructions
- Added to config set allowlist

## Test plan
- [ ] `think config set cortex.selectivity high` — sets value
- [ ] `think curate --dry-run` with selectivity high — fewer memories promoted
- [ ] `think config set cortex.granularity summary` — memories consolidated
- [ ] `think config set cortex.maxMemoriesPerRun 2` — at most 2 memories per run
- [ ] `think config set cortex.selectivity foo` — accepted (validation of enum values is a follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)