### PR TITLE
Add THINK_HOME env var for data directory isolation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "think",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "think",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.98",
         "chalk": "^5.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "think",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "think",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.98",
         "chalk": "^5.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-think",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "module",
   "description": "Local-first CLI that gives AI agents persistent, curated memory",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-think",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "description": "Local-first CLI that gives AI agents persistent, curated memory",
   "bin": {

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -2,15 +2,12 @@ import path from 'node:path';
 import fs from 'node:fs';
 import { DatabaseSync } from 'node:sqlite';
 import { ensureSchema } from './schema.js';
+import { getThinkDataDir } from '../lib/paths.js';
 
 let db: DatabaseSync | null = null;
 
 export function getDataDir(): string {
-  if (process.env.THINK_HOME) {
-    return process.env.THINK_HOME;
-  }
-  const xdgData = process.env.XDG_DATA_HOME || path.join(process.env.HOME!, '.local', 'share');
-  return path.join(xdgData, 'think');
+  return getThinkDataDir();
 }
 
 export function getDb(): DatabaseSync {

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -6,6 +6,9 @@ import { ensureSchema } from './schema.js';
 let db: DatabaseSync | null = null;
 
 export function getDataDir(): string {
+  if (process.env.THINK_HOME) {
+    return process.env.THINK_HOME;
+  }
   const xdgData = process.env.XDG_DATA_HOME || path.join(process.env.HOME!, '.local', 'share');
   return path.join(xdgData, 'think');
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -22,6 +22,9 @@ export interface Config {
 }
 
 export function getConfigDir(): string {
+  if (process.env.THINK_HOME) {
+    return process.env.THINK_HOME;
+  }
   const xdgConfig = process.env.XDG_CONFIG_HOME || path.join(process.env.HOME!, '.config');
   return path.join(xdgConfig, 'think');
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import fs from 'node:fs';
 import { v4 as uuidv4 } from 'uuid';
+import { getThinkConfigDir } from './paths.js';
 
 export interface CortexConfig {
   repo: string;
@@ -22,11 +23,7 @@ export interface Config {
 }
 
 export function getConfigDir(): string {
-  if (process.env.THINK_HOME) {
-    return process.env.THINK_HOME;
-  }
-  const xdgConfig = process.env.XDG_CONFIG_HOME || path.join(process.env.HOME!, '.config');
-  return path.join(xdgConfig, 'think');
+  return getThinkConfigDir();
 }
 
 function configPath(): string {

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -16,8 +16,28 @@ function sanitizeName(name: string): string {
   return name;
 }
 
+function getThinkHome(): string | null {
+  const thinkHome = process.env.THINK_HOME;
+  if (thinkHome === undefined || thinkHome === '') return null;
+  return thinkHome;
+}
+
 export function getThinkDir(): string {
-  return process.env.THINK_HOME ?? path.join(getHome(), '.think');
+  return getThinkHome() ?? path.join(getHome(), '.think');
+}
+
+export function getThinkConfigDir(): string {
+  const thinkHome = getThinkHome();
+  if (thinkHome) return path.join(thinkHome, 'config');
+  const xdgConfig = process.env.XDG_CONFIG_HOME || path.join(getHome(), '.config');
+  return path.join(xdgConfig, 'think');
+}
+
+export function getThinkDataDir(): string {
+  const thinkHome = getThinkHome();
+  if (thinkHome) return path.join(thinkHome, 'data');
+  const xdgData = process.env.XDG_DATA_HOME || path.join(getHome(), '.local', 'share');
+  return path.join(xdgData, 'think');
 }
 
 export function getEngramsDir(): string {

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -17,7 +17,7 @@ function sanitizeName(name: string): string {
 }
 
 export function getThinkDir(): string {
-  return path.join(getHome(), '.think');
+  return process.env.THINK_HOME ?? path.join(getHome(), '.think');
 }
 
 export function getEngramsDir(): string {


### PR DESCRIPTION
## Summary
- When `THINK_HOME` is set, all think data uses that directory (config, engrams, repo, longterm, curator.md)
- When unset, behavior is unchanged
- Enables isolated think instances per workspace (e.g., work vs personal kitty profiles)

## Test plan
- [ ] `THINK_HOME=/tmp/test think config show` — creates fresh config at `/tmp/test/config.json`
- [ ] `think config show` (no env var) — uses default config, unchanged
- [ ] `THINK_HOME=/tmp/test think sync "test"` — writes to `/tmp/test/think.db`
- [ ] Two workspaces with different `THINK_HOME` values never share data

🤖 Generated with [Claude Code](https://claude.com/claude-code)