### PR TITLE
Make list and summary commands cortex-aware

### DIFF
--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -52,17 +52,26 @@ export const listCommand = new Command('list')
 
     if (cortex) {
       // Read from cortex engram DB
+      if (opts.category || opts.tag) {
+        console.log(chalk.yellow('Note: --category and --tag filters are not supported for cortex engrams.'));
+      }
+
       let since: Date | undefined;
+      let until: Date | undefined;
       if (opts.week) {
         since = startOfWeek(new Date(), { weekStartsOn: 1 });
       } else if (opts.lastWeek) {
-        since = startOfWeek(subWeeks(new Date(), 1), { weekStartsOn: 1 });
-      } else if (opts.since) {
-        since = new Date(opts.since);
+        const lastWeekDate = subWeeks(new Date(), 1);
+        since = startOfWeek(lastWeekDate, { weekStartsOn: 1 });
+        until = endOfWeek(lastWeekDate, { weekStartsOn: 1 });
+      } else {
+        if (opts.since) since = new Date(opts.since);
+        if (opts.until) until = new Date(opts.until);
       }
 
       const engrams = getEngrams(cortex, {
         since,
+        until,
         limit: parseInt(opts.limit, 10),
       });
 

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -1,7 +1,11 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { getEntries, getEntriesByWeek, type Entry } from '../db/queries.js';
+import { getEngrams, type Engram } from '../db/engram-queries.js';
 import { closeDb } from '../db/client.js';
+import { closeEngramsDb } from '../db/engrams.js';
+import { getConfig } from '../lib/config.js';
+import { subWeeks, startOfWeek, endOfWeek } from 'date-fns';
 
 const categoryColors: Record<string, (s: string) => string> = {
   note: chalk.blue,
@@ -18,6 +22,12 @@ function formatEntry(entry: Entry): string {
   return `${chalk.gray(ts)}  ${badge} ${entry.content}`;
 }
 
+function formatEngram(engram: Engram): string {
+  const ts = engram.created_at.slice(0, 16).replace('T', ' ');
+  const badge = chalk.green('[engram]'.padEnd(12));
+  return `${chalk.gray(ts)}  ${badge} ${engram.content}`;
+}
+
 export const listCommand = new Command('list')
   .description('List entries with optional filters')
   .option('--since <date>', 'Show entries since date (ISO or YYYY-MM-DD)')
@@ -27,7 +37,7 @@ export const listCommand = new Command('list')
   .option('-n, --limit <n>', 'Max entries to show', '20')
   .option('-w, --week', 'Show current week')
   .option('--last-week', 'Show last week')
-  .action((opts: {
+  .action(function (this: Command, opts: {
     since?: string;
     until?: string;
     category?: string;
@@ -35,31 +45,64 @@ export const listCommand = new Command('list')
     limit: string;
     week?: boolean;
     lastWeek?: boolean;
-  }) => {
-    let entries: Entry[];
+  }) {
+    const globalOpts = this.optsWithGlobals() as { cortex?: string };
+    const config = getConfig();
+    const cortex = globalOpts.cortex ?? config.cortex?.active;
 
-    if (opts.week) {
-      entries = getEntriesByWeek(0);
-    } else if (opts.lastWeek) {
-      entries = getEntriesByWeek(1);
-    } else {
-      entries = getEntries({
-        since: opts.since ? new Date(opts.since) : undefined,
-        until: opts.until ? new Date(opts.until) : undefined,
-        category: opts.category,
-        tag: opts.tag,
+    if (cortex) {
+      // Read from cortex engram DB
+      let since: Date | undefined;
+      if (opts.week) {
+        since = startOfWeek(new Date(), { weekStartsOn: 1 });
+      } else if (opts.lastWeek) {
+        since = startOfWeek(subWeeks(new Date(), 1), { weekStartsOn: 1 });
+      } else if (opts.since) {
+        since = new Date(opts.since);
+      }
+
+      const engrams = getEngrams(cortex, {
+        since,
         limit: parseInt(opts.limit, 10),
       });
-    }
 
-    if (entries.length === 0) {
-      console.log(chalk.dim('No entries found.'));
-    } else {
-      for (const entry of entries) {
-        console.log(formatEntry(entry));
+      if (engrams.length === 0) {
+        console.log(chalk.dim('No engrams found.'));
+      } else {
+        for (const engram of engrams) {
+          console.log(formatEngram(engram));
+        }
+        console.log(chalk.dim(`\n${engrams.length} engrams`));
       }
-      console.log(chalk.dim(`\n${entries.length} entries`));
-    }
 
-    closeDb();
+      closeEngramsDb(cortex);
+    } else {
+      // Original path — local think.db
+      let entries: Entry[];
+
+      if (opts.week) {
+        entries = getEntriesByWeek(0);
+      } else if (opts.lastWeek) {
+        entries = getEntriesByWeek(1);
+      } else {
+        entries = getEntries({
+          since: opts.since ? new Date(opts.since) : undefined,
+          until: opts.until ? new Date(opts.until) : undefined,
+          category: opts.category,
+          tag: opts.tag,
+          limit: parseInt(opts.limit, 10),
+        });
+      }
+
+      if (entries.length === 0) {
+        console.log(chalk.dim('No entries found.'));
+      } else {
+        for (const entry of entries) {
+          console.log(formatEntry(entry));
+        }
+        console.log(chalk.dim(`\n${entries.length} entries`));
+      }
+
+      closeDb();
+    }
   });

--- a/src/commands/summary.ts
+++ b/src/commands/summary.ts
@@ -1,8 +1,12 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { getEntries, getEntriesByWeek, type Entry } from '../db/queries.js';
+import { getEngrams, type Engram } from '../db/engram-queries.js';
 import { generateSummary } from '../lib/claude.js';
 import { closeDb } from '../db/client.js';
+import { closeEngramsDb } from '../db/engrams.js';
+import { getConfig } from '../lib/config.js';
+import { subWeeks, startOfWeek } from 'date-fns';
 
 function formatRaw(entries: Entry[]): string {
   return entries
@@ -14,6 +18,26 @@ function formatRaw(entries: Entry[]): string {
     .join('\n');
 }
 
+function formatRawEngrams(engrams: Engram[]): string {
+  return engrams
+    .map((e) => {
+      const ts = e.created_at.slice(0, 16).replace('T', ' ');
+      return `${ts}  [engram]  ${e.content}`;
+    })
+    .join('\n');
+}
+
+function engramsToEntries(engrams: Engram[]): Entry[] {
+  return engrams.map((e) => ({
+    id: e.id,
+    timestamp: e.created_at,
+    source: 'cortex',
+    category: 'sync',
+    content: e.content,
+    tags: '[]',
+  }));
+}
+
 export const summaryCommand = new Command('summary')
   .description('Generate a summary of entries (AI-powered or raw)')
   .option('-w, --week', 'Current week (default)')
@@ -23,7 +47,7 @@ export const summaryCommand = new Command('summary')
   .option('-c, --category <category>', 'Filter by category')
   .option('-t, --tag <tag>', 'Filter by tag')
   .option('--raw', 'Skip AI formatting, just dump entries')
-  .action(async (opts: {
+  .action(async function (this: Command, opts: {
     week?: boolean;
     lastWeek?: boolean;
     since?: string;
@@ -31,53 +55,94 @@ export const summaryCommand = new Command('summary')
     category?: string;
     tag?: string;
     raw?: boolean;
-  }) => {
-    let entries: Entry[];
+  }) {
+    const globalOpts = this.optsWithGlobals() as { cortex?: string };
+    const config = getConfig();
+    const cortex = globalOpts.cortex ?? config.cortex?.active;
 
-    if (opts.lastWeek) {
-      entries = getEntriesByWeek(1);
-    } else if (opts.since || opts.until) {
-      entries = getEntries({
-        since: opts.since ? new Date(opts.since) : undefined,
-        until: opts.until ? new Date(opts.until) : undefined,
-        category: opts.category,
-        tag: opts.tag,
-      });
-    } else {
-      // Default to current week
-      entries = getEntriesByWeek(0);
-    }
-
-    // Apply category/tag filters for week-based queries too
-    if ((opts.week || opts.lastWeek || (!opts.since && !opts.until)) && (opts.category || opts.tag)) {
-      entries = entries.filter((e) => {
-        if (opts.category && e.category !== opts.category) return false;
-        if (opts.tag && !e.tags.includes(`"${opts.tag}"`)) return false;
-        return true;
-      });
-    }
-
-    if (entries.length === 0) {
-      console.log(chalk.dim('No entries found for the specified period.'));
-      closeDb();
-      return;
-    }
-
-    if (opts.raw) {
-      console.log(formatRaw(entries));
-      console.log(chalk.dim(`\n${entries.length} entries`));
-    } else {
-      try {
-        console.log(chalk.dim('Generating summary...'));
-        const summary = await generateSummary(entries);
-        console.log(summary);
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        console.error(chalk.red(`Error generating summary: ${msg}`));
-        console.log(chalk.dim('\nFalling back to raw output:\n'));
-        console.log(formatRaw(entries));
+    if (cortex) {
+      // Read from cortex engram DB
+      let since: Date | undefined;
+      if (opts.lastWeek) {
+        since = startOfWeek(subWeeks(new Date(), 1), { weekStartsOn: 1 });
+      } else if (opts.since) {
+        since = new Date(opts.since);
+      } else {
+        since = startOfWeek(new Date(), { weekStartsOn: 1 });
       }
-    }
 
-    closeDb();
+      const engrams = getEngrams(cortex, { since });
+
+      if (engrams.length === 0) {
+        console.log(chalk.dim('No engrams found for the specified period.'));
+        closeEngramsDb(cortex);
+        return;
+      }
+
+      if (opts.raw) {
+        console.log(formatRawEngrams(engrams));
+        console.log(chalk.dim(`\n${engrams.length} engrams`));
+      } else {
+        try {
+          console.log(chalk.dim('Generating summary...'));
+          const summary = await generateSummary(engramsToEntries(engrams));
+          console.log(summary);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          console.error(chalk.red(`Error generating summary: ${msg}`));
+          console.log(chalk.dim('\nFalling back to raw output:\n'));
+          console.log(formatRawEngrams(engrams));
+        }
+      }
+
+      closeEngramsDb(cortex);
+    } else {
+      // Original path — local think.db
+      let entries: Entry[];
+
+      if (opts.lastWeek) {
+        entries = getEntriesByWeek(1);
+      } else if (opts.since || opts.until) {
+        entries = getEntries({
+          since: opts.since ? new Date(opts.since) : undefined,
+          until: opts.until ? new Date(opts.until) : undefined,
+          category: opts.category,
+          tag: opts.tag,
+        });
+      } else {
+        entries = getEntriesByWeek(0);
+      }
+
+      if ((opts.week || opts.lastWeek || (!opts.since && !opts.until)) && (opts.category || opts.tag)) {
+        entries = entries.filter((e) => {
+          if (opts.category && e.category !== opts.category) return false;
+          if (opts.tag && !e.tags.includes(`"${opts.tag}"`)) return false;
+          return true;
+        });
+      }
+
+      if (entries.length === 0) {
+        console.log(chalk.dim('No entries found for the specified period.'));
+        closeDb();
+        return;
+      }
+
+      if (opts.raw) {
+        console.log(formatRaw(entries));
+        console.log(chalk.dim(`\n${entries.length} entries`));
+      } else {
+        try {
+          console.log(chalk.dim('Generating summary...'));
+          const summary = await generateSummary(entries);
+          console.log(summary);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          console.error(chalk.red(`Error generating summary: ${msg}`));
+          console.log(chalk.dim('\nFalling back to raw output:\n'));
+          console.log(formatRaw(entries));
+        }
+      }
+
+      closeDb();
+    }
   });

--- a/src/commands/summary.ts
+++ b/src/commands/summary.ts
@@ -31,8 +31,8 @@ function engramsToEntries(engrams: Engram[]): Entry[] {
   return engrams.map((e) => ({
     id: e.id,
     timestamp: e.created_at,
-    source: 'cortex',
-    category: 'sync',
+    source: 'manual',
+    category: 'note',
     content: e.content,
     tags: '[]',
   }));
@@ -73,29 +73,30 @@ export const summaryCommand = new Command('summary')
 
       const engrams = getEngrams(cortex, { since });
 
-      if (engrams.length === 0) {
-        console.log(chalk.dim('No engrams found for the specified period.'));
-        closeEngramsDb(cortex);
-        return;
-      }
-
-      if (opts.raw) {
-        console.log(formatRawEngrams(engrams));
-        console.log(chalk.dim(`\n${engrams.length} engrams`));
-      } else {
-        try {
-          console.log(chalk.dim('Generating summary...'));
-          const summary = await generateSummary(engramsToEntries(engrams));
-          console.log(summary);
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err);
-          console.error(chalk.red(`Error generating summary: ${msg}`));
-          console.log(chalk.dim('\nFalling back to raw output:\n'));
-          console.log(formatRawEngrams(engrams));
+      try {
+        if (engrams.length === 0) {
+          console.log(chalk.dim('No engrams found for the specified period.'));
+          return;
         }
-      }
 
-      closeEngramsDb(cortex);
+        if (opts.raw) {
+          console.log(formatRawEngrams(engrams));
+          console.log(chalk.dim(`\n${engrams.length} engrams`));
+        } else {
+          try {
+            console.log(chalk.dim('Generating summary...'));
+            const summary = await generateSummary(engramsToEntries(engrams));
+            console.log(summary);
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            console.error(chalk.red(`Error generating summary: ${msg}`));
+            console.log(chalk.dim('\nFalling back to raw output:\n'));
+            console.log(formatRawEngrams(engrams));
+          }
+        }
+      } finally {
+        closeEngramsDb(cortex);
+      }
     } else {
       // Original path — local think.db
       let entries: Entry[];

--- a/src/db/engram-queries.ts
+++ b/src/db/engram-queries.ts
@@ -38,7 +38,7 @@ export function getPendingEngrams(cortexName: string): Engram[] {
   ).all(new Date().toISOString()) as unknown as Engram[];
 }
 
-export function getEngrams(cortexName: string, params: { since?: Date; limit?: number }): Engram[] {
+export function getEngrams(cortexName: string, params: { since?: Date; until?: Date; limit?: number }): Engram[] {
   const db = getEngramsDb(cortexName);
   const conditions = ['deleted_at IS NULL'];
   const values: string[] = [];
@@ -46,6 +46,11 @@ export function getEngrams(cortexName: string, params: { since?: Date; limit?: n
   if (params.since) {
     conditions.push('created_at >= ?');
     values.push(params.since.toISOString());
+  }
+
+  if (params.until) {
+    conditions.push('created_at <= ?');
+    values.push(params.until.toISOString());
   }
 
   const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';


### PR DESCRIPTION
## Summary
- `think list` and `think summary` now read from the cortex engram DB when a cortex is active
- Falls back to original `think.db` behavior when no cortex is configured
- Fixes: engrams logged via `think sync` with a cortex active were invisible to `list` and `summary`

## Test plan
- [ ] With cortex active: `think list` shows engrams from cortex DB
- [ ] With cortex active: `think summary --raw` shows engrams from cortex DB
- [ ] Without cortex: `think list` reads from think.db as before
- [ ] `think list --week` with cortex — filters to current week
- [ ] `think summary` (AI mode) with cortex — generates summary from engrams

🤖 Generated with [Claude Code](https://claude.com/claude-code)