### PR TITLE
Fix version display in CLI and on marketing site

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -205,4 +205,15 @@
     if (el.closest('.view')) observer.observe(el);
   });
 
+  // Fetch latest published version from npm registry
+  fetch('https://registry.npmjs.org/open-think/latest')
+    .then(r => r.ok ? r.json() : null)
+    .then(data => {
+      if (!data?.version) return;
+      const label = 'v' + data.version;
+      document.getElementById('version-pill')?.replaceChildren(document.createTextNode(label));
+      document.getElementById('version-badge')?.replaceChildren(document.createTextNode(label));
+    })
+    .catch(() => {});
+
 })();

--- a/docs/index.html
+++ b/docs/index.html
@@ -21,7 +21,7 @@
     <button class="tab" data-tab="docs" role="tab"><span class="key">d</span>ocs</button>
     <div class="tab-spacer"></div>
     <div class="tab-meta">
-      <span class="pill">v0.1.7</span>
+      <span class="pill" id="version-pill">v0.1.7</span>
       <span class="dim">open-think · MIT</span>
     </div>
   </div>
@@ -44,7 +44,7 @@
       <!-- HOME VIEW -->
       <section class="view" data-view="home">
         <div class="hero">
-          <div class="badge"><span class="dot"></span>v0.1.7 · open source · MIT</div>
+          <div class="badge"><span class="dot"></span><span id="version-badge">v0.1.7</span> · open source · MIT</div>
           <h1>memory for your<br><span class="accent">AI agents</span>.</h1>
           <p class="lead">A local-first CLI that gives agents persistent, curated memory. Log work as it happens. Let AI decide what matters. Recall it next session.</p>
           <div class="install-line"><span class="prompt">$</span>npm install -g open-think</div>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import fs from 'node:fs';
+import path from 'node:path';
 import { Command } from 'commander';
 import { logCommand, syncCommand } from './commands/log.js';
 import { listCommand } from './commands/list.js';
@@ -18,12 +20,21 @@ import { pauseCommand, resumeCommand } from './commands/pause.js';
 import { configCommand } from './commands/config-cmd.js';
 import { updateCommand } from './commands/update.js';
 
+function readPackageVersion(): string {
+  try {
+    const pkgPath = path.join(import.meta.dirname, '..', 'package.json');
+    return JSON.parse(fs.readFileSync(pkgPath, 'utf-8')).version ?? '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+}
+
 const program = new Command();
 
 program
   .name('think')
   .description('Local-first CLI tool for capturing notes, work logs, and ideas')
-  .version('0.1.0')
+  .version(readPackageVersion())
   .option('-C, --cortex <name>', 'Use a specific cortex for this command');
 
 program.addCommand(logCommand);


### PR DESCRIPTION
## Summary
- CLI `--version` was hardcoded to `0.1.0` in `src/index.ts`, so every release since 0.1.0 has reported the wrong version. Now read from `package.json` at runtime (matching the pattern in `src/lib/update-check.ts`).
- The marketing site at openthink.dev was hardcoding `v0.1.7` in two spots in `docs/index.html`. Added IDs to the version pill/badge and added a small fetch in `docs/app.js` that pulls the latest version from `registry.npmjs.org/open-think/latest` on page load. The site now stays in sync with npm automatically.

## Test plan
- [x] `npm run build && node dist/index.js --version` reports `0.1.11` (the actual installed version)
- [ ] After merge + publish, `think --version` reports the new version
- [ ] openthink.dev shows the latest npm version in both the header pill and hero badge