### PR TITLE
Add long-term memory consolidation

### DIFF
--- a/src/commands/curate.ts
+++ b/src/commands/curate.ts
@@ -5,12 +5,22 @@ import { getConfig } from '../lib/config.js';
 import { ensureRepoCloned, fetchBranch, readFileFromBranch, appendAndCommit } from '../lib/git.js';
 import { getPendingEngrams, markEvaluated, pruneExpiredEngrams } from '../db/engram-queries.js';
 import { closeEngramsDb } from '../db/engrams.js';
-import { readCuratorMd, assembleCurationPrompt, parseMemoriesJsonl, runCuration } from '../lib/curator.js';
+import {
+  readCuratorMd,
+  readLongtermSummary,
+  writeLongtermSummary,
+  assembleCurationPrompt,
+  parseMemoriesJsonl,
+  filterRecentMemories,
+  runCuration,
+  runConsolidation,
+} from '../lib/curator.js';
 
 export const curateCommand = new Command('curate')
   .description('Run curation: evaluate pending engrams and append memories to the cortex branch')
   .option('--dry-run', 'Preview what would be committed without pushing')
-  .action(async (opts: { dryRun?: boolean }) => {
+  .option('--consolidate', 'Run long-term memory consolidation only (no curation)')
+  .action(async (opts: { dryRun?: boolean; consolidate?: boolean }) => {
     const config = getConfig();
     const cortex = config.cortex?.active;
 
@@ -30,11 +40,42 @@ export const curateCommand = new Command('curate')
     ensureRepoCloned();
     fetchBranch(cortex);
 
-    // 2. Read existing memories from branch
+    // 2. Read all memories from branch and split into recent vs older
     const memoriesRaw = readFileFromBranch(cortex, 'memories.jsonl') ?? '';
-    const existingMemories = parseMemoriesJsonl(memoriesRaw);
+    const allMemories = parseMemoriesJsonl(memoriesRaw);
+    const { recent, older } = filterRecentMemories(allMemories);
 
-    // 3. Read pending engrams
+    // 3. Read existing long-term summary
+    const longtermSummary = readLongtermSummary(cortex);
+
+    // Handle --consolidate: just run long-term memory consolidation
+    if (opts.consolidate) {
+      if (older.length === 0) {
+        console.log(chalk.dim('No memories older than 2 weeks to consolidate.'));
+        return;
+      }
+
+      console.log(chalk.cyan(`Consolidating ${older.length} older memories into long-term summary...`));
+
+      try {
+        const newSummary = await runConsolidation(longtermSummary, older);
+        if (opts.dryRun) {
+          console.log();
+          console.log(chalk.cyan('Proposed long-term summary:'));
+          console.log(newSummary);
+          return;
+        }
+        writeLongtermSummary(cortex, newSummary);
+        console.log(chalk.green('✓') + ` Long-term summary updated (${older.length} memories consolidated)`);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(chalk.red(`Consolidation failed: ${message}`));
+        process.exit(1);
+      }
+      return;
+    }
+
+    // 4. Read pending engrams
     const pending = getPendingEngrams(cortex);
     if (pending.length === 0) {
       console.log(chalk.dim('No pending engrams to evaluate.'));
@@ -42,14 +83,15 @@ export const curateCommand = new Command('curate')
       return;
     }
 
-    console.log(chalk.cyan(`Evaluating ${pending.length} engrams against ${existingMemories.length} existing memories...`));
+    console.log(chalk.cyan(`Evaluating ${pending.length} engrams (${recent.length} recent memories, long-term summary ${longtermSummary ? 'loaded' : 'absent'})...`));
 
-    // 4. Read curator.md
+    // 5. Read curator.md
     const curatorMd = readCuratorMd();
 
-    // 5. Assemble and run curation prompt
+    // 6. Assemble and run curation prompt (recent memories + longterm summary, not all memories)
     const prompt = assembleCurationPrompt({
-      existingMemories,
+      recentMemories: recent,
+      longtermSummary,
       curatorMd,
       pendingEngrams: pending,
       author,
@@ -74,7 +116,7 @@ export const curateCommand = new Command('curate')
       if (!entry.ts) entry.ts = new Date().toISOString();
     }
 
-    // 6. Identify promoted and dropped engram IDs
+    // 7. Identify promoted and dropped engram IDs
     const promotedIds = new Set<string>();
     for (const entry of newEntries) {
       for (const id of entry.source_ids) {
@@ -86,7 +128,7 @@ export const curateCommand = new Command('curate')
       .filter(e => !promotedIds.has(e.id))
       .map(e => e.id);
 
-    // 7. Dry run — show preview and exit
+    // 8. Dry run — show preview and exit
     if (opts.dryRun) {
       console.log();
       if (newEntries.length === 0) {
@@ -103,7 +145,7 @@ export const curateCommand = new Command('curate')
       return;
     }
 
-    // 8. Confirm before commit (if configured)
+    // 9. Confirm before commit (if configured)
     if (config.cortex?.confirmBeforeCommit && newEntries.length > 0) {
       console.log();
       console.log(chalk.cyan('Proposed memories:'));
@@ -127,7 +169,6 @@ export const curateCommand = new Command('curate')
       }
 
       if (answer === 'e' || answer === 'edit') {
-        // Let user edit each entry
         for (let i = 0; i < newEntries.length; i++) {
           const editRl = readline.createInterface({ input: process.stdin, output: process.stdout });
           const edited = await new Promise<string>((resolve) => {
@@ -143,7 +184,7 @@ export const curateCommand = new Command('curate')
       }
     }
 
-    // 9. Append to memories.jsonl and push
+    // 10. Append to memories.jsonl and push
     if (newEntries.length > 0) {
       const newLines = newEntries.map(e => JSON.stringify(e));
       const commitMsg = `curate: ${author}, ${pending.length} engrams, ${newEntries.length} memories`;
@@ -158,7 +199,7 @@ export const curateCommand = new Command('curate')
       }
     }
 
-    // 9. Mark engrams as evaluated
+    // 11. Mark engrams as evaluated
     if (promotedIds.size > 0) {
       markEvaluated(cortex, [...promotedIds], true);
     }
@@ -166,10 +207,22 @@ export const curateCommand = new Command('curate')
       markEvaluated(cortex, droppedIds, false);
     }
 
-    // 10. Prune expired engrams
+    // 12. Prune expired engrams
     const pruned = pruneExpiredEngrams(cortex);
 
-    // 11. Report
+    // 13. Auto-consolidate if there are older memories and no long-term summary yet (or it's stale)
+    if (older.length > 0 && !longtermSummary) {
+      console.log(chalk.dim(`  Consolidating ${older.length} older memories into long-term summary...`));
+      try {
+        const newSummary = await runConsolidation(null, older);
+        writeLongtermSummary(cortex, newSummary);
+        console.log(chalk.dim(`  Long-term summary created`));
+      } catch {
+        console.log(chalk.dim(`  Long-term consolidation skipped (will retry next run)`));
+      }
+    }
+
+    // 14. Report
     console.log();
     console.log(`${chalk.green('✓')} Curation complete`);
     console.log(`  ${pending.length} evaluated, ${newEntries.length} promoted, ${droppedIds.length} dropped`);

--- a/src/lib/curator.ts
+++ b/src/lib/curator.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import { query } from '@anthropic-ai/claude-agent-sdk';
-import { getCuratorMdPath } from './paths.js';
+import { getCuratorMdPath, getLongtermPath, ensureThinkDirs } from './paths.js';
 import type { Engram } from '../db/engram-queries.js';
 
 export interface MemoryEntry {
@@ -12,8 +12,11 @@ export interface MemoryEntry {
 
 const BASE_CURATION_PROMPT = `You are a memory curator. You evaluate recent work events and decide which ones are significant enough to become shared team memory.
 
-## What the team already knows
-{existing_memories}
+## Long-term context (compressed history)
+{longterm_summary}
+
+## Recent team memories (last 2 weeks)
+{recent_memories}
 
 ## What this contributor considers worth sharing
 {curator_md}
@@ -25,7 +28,7 @@ const BASE_CURATION_PROMPT = `You are a memory curator. You evaluate recent work
 
 Your task:
 
-1. Read what the team already knows to avoid redundancy.
+1. Read the long-term context and recent memories to avoid redundancy.
 2. Read the contributor's guidance (if provided) for their priorities.
 3. For each event, decide: is this something the team should remember?
    Look for:
@@ -58,6 +61,28 @@ Rules:
 - Do not repeat information already in the team's memory
 - Only add an entry if there is genuinely new information`;
 
+const CONSOLIDATION_PROMPT = `You are a memory consolidator. You compress older detailed memories into a concise long-term summary.
+
+## Existing long-term summary
+{existing_longterm}
+
+## Memories to consolidate (these are aging out of the short-term window)
+{aging_memories}
+
+---
+
+Your task:
+
+Produce an updated long-term summary that incorporates the aging memories into the existing summary. The summary should:
+
+- Capture key projects, decisions, and milestones — not individual commits
+- Preserve what's still relevant from the existing summary
+- Group related work into coherent themes
+- Be concise — aim for 500-1000 words total
+- Write for an agent that needs historical context, not a detailed log
+
+Return only the updated summary text. No JSON, no formatting, no explanation.`;
+
 export function readCuratorMd(): string | null {
   const mdPath = getCuratorMdPath();
   if (fs.existsSync(mdPath)) {
@@ -66,8 +91,40 @@ export function readCuratorMd(): string | null {
   return null;
 }
 
+export function readLongtermSummary(cortexName: string): string | null {
+  const ltPath = getLongtermPath(cortexName);
+  if (fs.existsSync(ltPath)) {
+    return fs.readFileSync(ltPath, 'utf-8').trim();
+  }
+  return null;
+}
+
+export function writeLongtermSummary(cortexName: string, summary: string): void {
+  ensureThinkDirs();
+  const ltPath = getLongtermPath(cortexName);
+  fs.writeFileSync(ltPath, summary, 'utf-8');
+}
+
+export function filterRecentMemories(memories: MemoryEntry[], windowDays: number = 14): {
+  recent: MemoryEntry[];
+  older: MemoryEntry[];
+} {
+  const cutoff = new Date(Date.now() - windowDays * 86400000).toISOString();
+  const recent: MemoryEntry[] = [];
+  const older: MemoryEntry[] = [];
+  for (const m of memories) {
+    if (m.ts >= cutoff) {
+      recent.push(m);
+    } else {
+      older.push(m);
+    }
+  }
+  return { recent, older };
+}
+
 export function assembleCurationPrompt(params: {
-  existingMemories: MemoryEntry[];
+  recentMemories: MemoryEntry[];
+  longtermSummary: string | null;
   curatorMd: string | null;
   pendingEngrams: Engram[];
   author: string;
@@ -75,11 +132,13 @@ export function assembleCurationPrompt(params: {
   granularity?: 'detailed' | 'summary';
   maxMemoriesPerRun?: number;
 }): string {
-  const memoriesText = params.existingMemories.length > 0
-    ? params.existingMemories
+  const longtermText = params.longtermSummary ?? '(no long-term context yet)';
+
+  const recentText = params.recentMemories.length > 0
+    ? params.recentMemories
         .map(m => `- [${m.ts}] ${m.author}: ${m.content}`)
         .join('\n')
-    : '(no memories yet)';
+    : '(no recent memories)';
 
   const curatorMdText = params.curatorMd ?? '(none provided)';
 
@@ -88,7 +147,8 @@ export function assembleCurationPrompt(params: {
     .join('\n');
 
   let prompt = BASE_CURATION_PROMPT
-    .replace('{existing_memories}', memoriesText)
+    .replace('{longterm_summary}', longtermText)
+    .replace('{recent_memories}', recentText)
     .replace('{curator_md}', curatorMdText)
     .replace('{pending_engrams}', engramsText);
 
@@ -191,4 +251,37 @@ export async function runCuration(prompt: string): Promise<MemoryEntry[]> {
   });
 
   return entries;
+}
+
+export async function runConsolidation(existingLongterm: string | null, agingMemories: MemoryEntry[]): Promise<string> {
+  const existingText = existingLongterm ?? '(no existing summary)';
+  const agingText = agingMemories
+    .map(m => `- [${m.ts}] ${m.author}: ${m.content}`)
+    .join('\n');
+
+  const prompt = CONSOLIDATION_PROMPT
+    .replace('{existing_longterm}', existingText)
+    .replace('{aging_memories}', agingText);
+
+  let result = '';
+
+  for await (const message of query({
+    prompt,
+    options: {
+      systemPrompt: 'You are a memory consolidator. Return only the updated summary text. No JSON, no formatting.',
+      tools: [],
+      model: 'claude-sonnet-4-6',
+      persistSession: false,
+    },
+  })) {
+    if ('result' in message && typeof message.result === 'string') {
+      result = message.result;
+    }
+  }
+
+  if (!result) {
+    throw new Error('No result returned from consolidation');
+  }
+
+  return result.trim();
 }


### PR DESCRIPTION
## Summary
- Curation now uses a 2-week rolling window — reads recent memories + local long-term summary instead of all 780+ memories
- Long-term summary is produced by consolidation: compresses older memories into a concise local file
- `think curate --consolidate` runs consolidation only
- `think curate --consolidate --dry-run` previews the summary
- Auto-consolidates on first curation run if older memories exist and no summary yet
- Long-term summary is local-only, never pushed, reconstructable from the branch

## Test plan
- [ ] `think curate --consolidate --dry-run` — shows proposed long-term summary from older memories
- [ ] `think curate --consolidate` — writes summary to `~/.think/longterm/<cortex>.md`
- [ ] `think curate` with pending engrams — only sends recent memories + longterm summary to LLM, not all 780
- [ ] `think curate` with older memories and no existing summary — auto-consolidates
- [ ] Verify curation still works end-to-end: engrams evaluated, memories appended, pushed

🤖 Generated with [Claude Code](https://claude.com/claude-code)