### PR TITLE
File bucketing: split memories into ~500-line numbered files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "think",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "think",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.98",
         "chalk": "^5.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-think",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "description": "Local-first CLI that gives AI agents persistent, curated memory",
   "bin": {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -12,6 +12,8 @@ export interface CortexConfig {
   selectivity?: 'low' | 'medium' | 'high';
   granularity?: 'detailed' | 'summary';
   maxMemoriesPerRun?: number;
+  bucketSize?: number;
+  onboardingDepth?: number;
 }
 
 export interface Config {

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -156,8 +156,12 @@ export function migrateToBuckets(branchName: string): void {
   try { runGit(['switch', branchName]); }
   catch { runGit(['switch', '-c', branchName, `origin/${branchName}`]); }
 
+  // pull --rebase updates local branch pointer + working tree from remote.
+  // Caller already called fetchBranch (updates remote refs), so this pull
+  // is fast. appendAndCommit also does pull --rebase, but that's a no-op
+  // if nothing changed between migration and append.
   try { runGit(['pull', '--rebase', 'origin', branchName]); }
-  catch { /* same as appendAndCommit — tolerate upstream issues */ }
+  catch { /* tolerate upstream issues (e.g. first push) */ }
 
   const legacyPath = path.join(repoPath, 'memories.jsonl');
   const bucketPath = path.join(repoPath, '000001.jsonl');
@@ -176,7 +180,9 @@ export function migrateToBuckets(branchName: string): void {
         return;
       } catch {
         if (attempt === 3) {
-          // Rollback to exact pre-migration state (restores memories.jsonl, removes 000001.jsonl)
+          // Rollback to pre-migration commit. That commit has memories.jsonl
+          // (the rename to 000001.jsonl happened after it), so --hard reset
+          // restores memories.jsonl and removes 000001.jsonl from working tree.
           try { runGit(['reset', '--hard', preMigrationRef]); } catch { /* best effort */ }
           throw new Error('Migration push failed after 3 attempts — local commit rolled back');
         }

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -163,6 +163,9 @@ export function migrateToBuckets(branchName: string): void {
   const bucketPath = path.join(repoPath, '000001.jsonl');
 
   if (fs.existsSync(legacyPath) && !fs.existsSync(bucketPath)) {
+    // Save pre-migration ref for rollback
+    const preMigrationRef = runGit(['rev-parse', 'HEAD']);
+
     fs.renameSync(legacyPath, bucketPath);
     runGit(['add', '-A']);
     runGit(['commit', '-m', 'migrate: memories.jsonl -> 000001.jsonl']);
@@ -173,8 +176,8 @@ export function migrateToBuckets(branchName: string): void {
         return;
       } catch {
         if (attempt === 3) {
-          // Rollback local commit and restore working tree to pre-migration state
-          try { runGit(['reset', '--hard', 'HEAD~1']); } catch { /* best effort */ }
+          // Rollback to exact pre-migration state (restores memories.jsonl, removes 000001.jsonl)
+          try { runGit(['reset', '--hard', preMigrationRef]); } catch { /* best effort */ }
           throw new Error('Migration push failed after 3 attempts — local commit rolled back');
         }
         runGit(['pull', '--rebase', 'origin', branchName]);

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -173,8 +173,8 @@ export function migrateToBuckets(branchName: string): void {
         return;
       } catch {
         if (attempt === 3) {
-          // Rollback local commit to avoid diverged state
-          try { runGit(['reset', 'HEAD~1']); } catch { /* best effort */ }
+          // Rollback local commit and restore working tree to pre-migration state
+          try { runGit(['reset', '--hard', 'HEAD~1']); } catch { /* best effort */ }
           throw new Error('Migration push failed after 3 attempts — local commit rolled back');
         }
         runGit(['pull', '--rebase', 'origin', branchName]);

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -172,7 +172,11 @@ export function migrateToBuckets(branchName: string): void {
         runGit(['push', 'origin', branchName]);
         return;
       } catch {
-        if (attempt === 3) throw new Error('Migration push failed after 3 attempts');
+        if (attempt === 3) {
+          // Rollback local commit to avoid diverged state
+          try { runGit(['reset', 'HEAD~1']); } catch { /* best effort */ }
+          throw new Error('Migration push failed after 3 attempts — local commit rolled back');
+        }
         runGit(['pull', '--rebase', 'origin', branchName]);
       }
     }

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -54,8 +54,8 @@ export function createOrphanBranch(branchName: string): void {
   }
 
   const repoPath = getRepoPath();
-  fs.writeFileSync(path.join(repoPath, 'memories.jsonl'), '', 'utf-8');
-  runGit(['add', 'memories.jsonl']);
+  fs.writeFileSync(path.join(repoPath, '000001.jsonl'), '', 'utf-8');
+  runGit(['add', '000001.jsonl']);
   runGit(['commit', '-m', `init: create cortex ${branchName}`]);
   runGit(['push', '--set-upstream', 'origin', branchName]);
 }
@@ -77,9 +77,10 @@ export function appendAndCommit(
   newLines: string[],
   commitMessage: string,
   maxRetries: number = 3,
+  targetFile: string = 'memories.jsonl',
 ): void {
   const repoPath = getRepoPath();
-  const memoriesPath = path.join(repoPath, 'memories.jsonl');
+  const filePath = path.join(repoPath, targetFile);
 
   try {
     runGit(['switch', branchName]);
@@ -95,14 +96,14 @@ export function appendAndCommit(
     const message = err instanceof Error ? err.message : String(err);
     if (message.includes('CONFLICT') || message.includes('could not apply')) {
       try { runGit(['rebase', '--abort']); } catch { /* best effort */ }
-      throw new Error(`Rebase conflict on ${branchName}. This should not happen with append-only files — check for manual edits to memories.jsonl.`);
+      throw new Error(`Rebase conflict on ${branchName}. This should not happen with append-only files.`);
     }
   }
 
   const content = newLines.join('\n') + '\n';
-  fs.appendFileSync(memoriesPath, content, 'utf-8');
+  fs.appendFileSync(filePath, content, 'utf-8');
 
-  runGit(['add', 'memories.jsonl']);
+  runGit(['add', targetFile]);
   runGit(['commit', '-m', commitMessage]);
 
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
@@ -128,4 +129,43 @@ export function listRemoteBranches(): string[] {
     .filter(Boolean)
     .map(line => line.split('\t')[1]?.replace('refs/heads/', ''))
     .filter(Boolean) as string[];
+}
+
+export function listBranchFiles(branchName: string, extension?: string): string[] {
+  try {
+    const output = runGit(['ls-tree', '--name-only', `origin/${branchName}`]);
+    let files = output.split('\n').filter(Boolean);
+    if (extension) {
+      files = files.filter(f => f.endsWith(extension));
+    }
+    return files.sort();
+  } catch {
+    return [];
+  }
+}
+
+export function countBranchFileLines(branchName: string, filePath: string): number {
+  const content = readFileFromBranch(branchName, filePath);
+  if (!content) return 0;
+  return content.trim().split('\n').filter(Boolean).length;
+}
+
+export function migrateToBuckets(branchName: string): void {
+  const repoPath = getRepoPath();
+
+  try { runGit(['switch', branchName]); }
+  catch { runGit(['switch', '-c', branchName, `origin/${branchName}`]); }
+
+  try { runGit(['pull', '--rebase', 'origin', branchName]); }
+  catch { /* same as appendAndCommit — tolerate upstream issues */ }
+
+  const legacyPath = path.join(repoPath, 'memories.jsonl');
+  const bucketPath = path.join(repoPath, '000001.jsonl');
+
+  if (fs.existsSync(legacyPath) && !fs.existsSync(bucketPath)) {
+    fs.renameSync(legacyPath, bucketPath);
+    runGit(['add', '-A']);
+    runGit(['commit', '-m', 'migrate: memories.jsonl -> 000001.jsonl']);
+    runGit(['push', 'origin', branchName]);
+  }
 }

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -166,6 +166,15 @@ export function migrateToBuckets(branchName: string): void {
     fs.renameSync(legacyPath, bucketPath);
     runGit(['add', '-A']);
     runGit(['commit', '-m', 'migrate: memories.jsonl -> 000001.jsonl']);
-    runGit(['push', 'origin', branchName]);
+
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      try {
+        runGit(['push', 'origin', branchName]);
+        return;
+      } catch {
+        if (attempt === 3) throw new Error('Migration push failed after 3 attempts');
+        runGit(['pull', '--rebase', 'origin', branchName]);
+      }
+    }
   }
 }

--- a/src/sync/git-adapter.ts
+++ b/src/sync/git-adapter.ts
@@ -68,6 +68,8 @@ export class GitSyncAdapter implements SyncAdapter {
     const lastVersion = cursorStr ? parseInt(cursorStr, 10) : 0;
 
     // Ensure legacy memories.jsonl is migrated to bucketed format
+    // (fetchBranch happens inside appendAndCommit via pull --rebase,
+    // but we need fresh remote state for migration check and bucket determination)
     fetchBranch(cortex);
     this.ensureMigrated(cortex);
 
@@ -184,18 +186,24 @@ export class GitSyncAdapter implements SyncAdapter {
     }
 
     // Process files in ascending order (critical for tombstone correctness)
-    let lastProcessedFile: string | null = null;
+    let lastReadFile: string | null = null;
     for (const file of filesToRead) {
-      const raw = readFileFromBranch(cortex, file) ?? '';
-      if (raw) {
+      const raw = readFileFromBranch(cortex, file);
+      if (raw === null) {
+        // File failed to read (shouldn't happen after fetch) — stop advancing cursor
+        break;
+      }
+      // Advance cursor past this file even if empty (empty file = nothing to process,
+      // but we've confirmed it exists and was read — don't re-read it forever)
+      lastReadFile = file;
+      if (raw.trim()) {
         this.processMemories(cortex, raw, result);
-        lastProcessedFile = file;
       }
     }
 
-    // Only advance cursor to the last file we actually read content from
-    if (lastProcessedFile) {
-      setSyncCursor(cortex, 'git', 'pull_file', lastProcessedFile);
+    // Advance cursor to the last file we successfully read (empty or not)
+    if (lastReadFile) {
+      setSyncCursor(cortex, 'git', 'pull_file', lastReadFile);
     }
 
     return result;

--- a/src/sync/git-adapter.ts
+++ b/src/sync/git-adapter.ts
@@ -183,14 +183,15 @@ export class GitSyncAdapter implements SyncAdapter {
       }
     }
 
-    // Process files in ascending order (critical for tombstone correctness)
+    // Process files in ascending order (critical for tombstone correctness).
+    // Stop at the first read failure — don't advance cursor past a gap.
     let lastReadFile: string | null = null;
     for (const file of filesToRead) {
       const raw = readFileFromBranch(cortex, file);
       if (raw === null) {
-        // Transient read failure — skip this file but continue processing remaining
-        // files. Cursor won't advance past it, so it gets retried on next pull.
-        continue;
+        // Read failure — stop here. Cursor stays at lastReadFile so this
+        // file and all subsequent files get retried on next pull.
+        break;
       }
       lastReadFile = file;
       if (raw.trim()) {

--- a/src/sync/git-adapter.ts
+++ b/src/sync/git-adapter.ts
@@ -30,10 +30,8 @@ export class GitSyncAdapter implements SyncAdapter {
     return !!config.cortex?.repo;
   }
 
-  private ensureMigrated(cortex: string): void {
-    fetchBranch(cortex);
-    const files = listBranchFiles(cortex, '.jsonl');
-    const hasNumbered = files.some(f => /^\d{6}\.jsonl$/.test(f));
+  private ensureMigrated(cortex: string, branchFiles: string[]): void {
+    const hasNumbered = branchFiles.some(f => /^\d{6}\.jsonl$/.test(f));
     if (!hasNumbered) {
       const hasLegacy = readFileFromBranch(cortex, 'memories.jsonl') !== null;
       if (hasLegacy) {
@@ -42,14 +40,14 @@ export class GitSyncAdapter implements SyncAdapter {
     }
   }
 
-  private determineBucketFile(cortex: string): string {
+  private determineBucketFile(cortex: string, branchFiles: string[]): string {
     const config = getConfig();
     const bucketSize = config.cortex?.bucketSize ?? 500;
 
-    const files = listBranchFiles(cortex, '.jsonl').filter(f => /^\d{6}\.jsonl$/.test(f));
-    if (files.length === 0) return '000001.jsonl';
+    const numbered = branchFiles.filter(f => /^\d{6}\.jsonl$/.test(f));
+    if (numbered.length === 0) return '000001.jsonl';
 
-    const latestFile = files[files.length - 1];
+    const latestFile = numbered[numbered.length - 1];
     const lineCount = countBranchFileLines(cortex, latestFile);
 
     if (lineCount >= bucketSize) {
@@ -63,20 +61,27 @@ export class GitSyncAdapter implements SyncAdapter {
     const result: SyncResult = { pushed: 0, pulled: 0, errors: [] };
 
     ensureRepoCloned();
+    fetchBranch(cortex);
 
     // Get last push cursor (sync_version)
     const cursorStr = getSyncCursor(cortex, 'git', 'push');
     const lastVersion = cursorStr ? parseInt(cursorStr, 10) : 0;
 
-    // Ensure legacy memories.jsonl is migrated to bucketed format
-    this.ensureMigrated(cortex);
+    // Single fetch, read file list once, pass to both migration check and bucket determination
+    const branchFiles = listBranchFiles(cortex, '.jsonl');
+    this.ensureMigrated(cortex, branchFiles);
+
+    // Re-read after potential migration (migration changes the file list)
+    const currentFiles = branchFiles.some(f => /^\d{6}\.jsonl$/.test(f))
+      ? branchFiles
+      : listBranchFiles(cortex, '.jsonl');
 
     // Get memories created since last push
     const newMemories = getMemoriesBySyncVersion(cortex, lastVersion);
     if (newMemories.length === 0) return result;
 
     // Determine which bucket file to write to
-    const targetFile = this.determineBucketFile(cortex);
+    const targetFile = this.determineBucketFile(cortex, currentFiles);
 
     // Format as JSONL lines (include episode_key and deleted_at when present)
     const newLines = newMemories.map(m => JSON.stringify({

--- a/src/sync/git-adapter.ts
+++ b/src/sync/git-adapter.ts
@@ -92,12 +92,17 @@ export class GitSyncAdapter implements SyncAdapter {
     const commitMsg = `curate: ${config.cortex?.author ?? 'unknown'}, ${newMemories.length} memories`;
     const maxVersion = Math.max(...newMemories.map(m => m.sync_version));
 
+    // Update cursor optimistically — if push fails, restore the old cursor.
+    // If the process dies between push and cursor restore, the next push
+    // re-sends the same memories, but pull uses INSERT OR IGNORE with
+    // deterministic IDs so duplicates in JSONL are harmless.
     setSyncCursor(cortex, 'git', 'push', String(maxVersion));
 
     try {
       appendAndCommit(cortex, newLines, commitMsg, 3, targetFile);
       result.pushed = newMemories.length;
     } catch (err) {
+      // Restore cursor on failure so we retry next time
       setSyncCursor(cortex, 'git', 'push', String(lastVersion));
       result.errors.push(err instanceof Error ? err.message : String(err));
     }
@@ -179,16 +184,18 @@ export class GitSyncAdapter implements SyncAdapter {
     }
 
     // Process files in ascending order (critical for tombstone correctness)
+    let lastProcessedFile: string | null = null;
     for (const file of filesToRead) {
       const raw = readFileFromBranch(cortex, file) ?? '';
       if (raw) {
         this.processMemories(cortex, raw, result);
+        lastProcessedFile = file;
       }
     }
 
-    // Update pull cursor to the latest file
-    if (files.length > 0) {
-      setSyncCursor(cortex, 'git', 'pull_file', files[files.length - 1]);
+    // Only advance cursor to the last file we actually read content from
+    if (lastProcessedFile) {
+      setSyncCursor(cortex, 'git', 'pull_file', lastProcessedFile);
     }
 
     return result;

--- a/src/sync/git-adapter.ts
+++ b/src/sync/git-adapter.ts
@@ -6,6 +6,9 @@ import {
   createOrphanBranch,
   branchExists,
   listRemoteBranches,
+  listBranchFiles,
+  countBranchFileLines,
+  migrateToBuckets,
 } from '../lib/git.js';
 import { parseMemoriesJsonl } from '../lib/curator.js';
 import {
@@ -27,6 +30,34 @@ export class GitSyncAdapter implements SyncAdapter {
     return !!config.cortex?.repo;
   }
 
+  private ensureMigrated(cortex: string): void {
+    const files = listBranchFiles(cortex, '.jsonl');
+    const hasNumbered = files.some(f => /^\d{6}\.jsonl$/.test(f));
+    if (!hasNumbered) {
+      const hasLegacy = readFileFromBranch(cortex, 'memories.jsonl') !== null;
+      if (hasLegacy) {
+        migrateToBuckets(cortex);
+      }
+    }
+  }
+
+  private determineBucketFile(cortex: string): string {
+    const config = getConfig();
+    const bucketSize = config.cortex?.bucketSize ?? 500;
+
+    const files = listBranchFiles(cortex, '.jsonl').filter(f => /^\d{6}\.jsonl$/.test(f));
+    if (files.length === 0) return '000001.jsonl';
+
+    const latestFile = files[files.length - 1];
+    const lineCount = countBranchFileLines(cortex, latestFile);
+
+    if (lineCount >= bucketSize) {
+      const nextNum = parseInt(latestFile.replace('.jsonl', ''), 10) + 1;
+      return String(nextNum).padStart(6, '0') + '.jsonl';
+    }
+    return latestFile;
+  }
+
   async push(cortex: string): Promise<SyncResult> {
     const result: SyncResult = { pushed: 0, pulled: 0, errors: [] };
 
@@ -36,9 +67,16 @@ export class GitSyncAdapter implements SyncAdapter {
     const cursorStr = getSyncCursor(cortex, 'git', 'push');
     const lastVersion = cursorStr ? parseInt(cursorStr, 10) : 0;
 
+    // Ensure legacy memories.jsonl is migrated to bucketed format
+    fetchBranch(cortex);
+    this.ensureMigrated(cortex);
+
     // Get memories created since last push
     const newMemories = getMemoriesBySyncVersion(cortex, lastVersion);
     if (newMemories.length === 0) return result;
+
+    // Determine which bucket file to write to
+    const targetFile = this.determineBucketFile(cortex);
 
     // Format as JSONL lines (include episode_key and deleted_at when present)
     const newLines = newMemories.map(m => JSON.stringify({
@@ -54,17 +92,12 @@ export class GitSyncAdapter implements SyncAdapter {
     const commitMsg = `curate: ${config.cortex?.author ?? 'unknown'}, ${newMemories.length} memories`;
     const maxVersion = Math.max(...newMemories.map(m => m.sync_version));
 
-    // Update cursor optimistically — if push fails, restore the old cursor.
-    // If the process dies between push and cursor restore, the next push
-    // re-sends the same memories, but pull uses INSERT OR IGNORE with
-    // deterministic IDs so duplicates in JSONL are harmless.
     setSyncCursor(cortex, 'git', 'push', String(maxVersion));
 
     try {
-      appendAndCommit(cortex, newLines, commitMsg);
+      appendAndCommit(cortex, newLines, commitMsg, 3, targetFile);
       result.pushed = newMemories.length;
     } catch (err) {
-      // Restore cursor on failure so we retry next time
       setSyncCursor(cortex, 'git', 'push', String(lastVersion));
       result.errors.push(err instanceof Error ? err.message : String(err));
     }
@@ -72,29 +105,14 @@ export class GitSyncAdapter implements SyncAdapter {
     return result;
   }
 
-  async pull(cortex: string): Promise<SyncResult> {
-    const result: SyncResult = { pushed: 0, pulled: 0, errors: [] };
-
-    try {
-      ensureRepoCloned();
-      fetchBranch(cortex);
-    } catch (err) {
-      result.errors.push(err instanceof Error ? err.message : String(err));
-      return result;
-    }
-
-    // Read full memories.jsonl from git
-    const memoriesRaw = readFileFromBranch(cortex, 'memories.jsonl') ?? '';
+  private processMemories(cortex: string, memoriesRaw: string, result: SyncResult): void {
     const memories = parseMemoriesJsonl(memoriesRaw);
 
-    // Diff against local — insert new, process tombstones
     for (const m of memories) {
       const id = deterministicId(m.ts, m.author, m.content);
 
       if (m.deleted_at) {
-        // Tombstone — soft delete the local copy. The JSONL tombstone line
-        // preserves the original ts/author/content (only deleted_at is added),
-        // so deterministicId produces the same ID as the original entry.
+        // Tombstone — preserves original ts/author/content so deterministicId matches
         tombstoneMemory(cortex, id);
         continue;
       }
@@ -108,6 +126,69 @@ export class GitSyncAdapter implements SyncAdapter {
         episode_key: m.episode_key,
       });
       if (wasInserted) result.pulled++;
+    }
+  }
+
+  async pull(cortex: string): Promise<SyncResult> {
+    const result: SyncResult = { pushed: 0, pulled: 0, errors: [] };
+
+    try {
+      ensureRepoCloned();
+      fetchBranch(cortex);
+    } catch (err) {
+      result.errors.push(err instanceof Error ? err.message : String(err));
+      return result;
+    }
+
+    const config = getConfig();
+    const onboardingDepth = config.cortex?.onboardingDepth ?? 1500;
+    const bucketSize = config.cortex?.bucketSize ?? 500;
+
+    // List numbered bucket files
+    const files = listBranchFiles(cortex, '.jsonl')
+      .filter(f => /^\d{6}\.jsonl$/.test(f))
+      .sort();
+
+    if (files.length === 0) {
+      // Legacy fallback: try memories.jsonl
+      const memoriesRaw = readFileFromBranch(cortex, 'memories.jsonl') ?? '';
+      if (memoriesRaw) {
+        this.processMemories(cortex, memoriesRaw, result);
+      }
+      return result;
+    }
+
+    // Determine which files to read
+    const pullCursor = getSyncCursor(cortex, 'git', 'pull_file');
+    let filesToRead: string[];
+
+    if (!pullCursor) {
+      // Onboarding: read last N files based on configured depth
+      const numFiles = Math.ceil(onboardingDepth / bucketSize);
+      filesToRead = files.slice(-numFiles);
+    } else {
+      // Incremental: read from cursor file onward (re-read cursor file to catch appends)
+      const cursorIndex = files.indexOf(pullCursor);
+      if (cursorIndex === -1) {
+        // Cursor file not found — fall back to onboarding
+        const numFiles = Math.ceil(onboardingDepth / bucketSize);
+        filesToRead = files.slice(-numFiles);
+      } else {
+        filesToRead = files.slice(cursorIndex);
+      }
+    }
+
+    // Process files in ascending order (critical for tombstone correctness)
+    for (const file of filesToRead) {
+      const raw = readFileFromBranch(cortex, file) ?? '';
+      if (raw) {
+        this.processMemories(cortex, raw, result);
+      }
+    }
+
+    // Update pull cursor to the latest file
+    if (files.length > 0) {
+      setSyncCursor(cortex, 'git', 'pull_file', files[files.length - 1]);
     }
 
     return result;

--- a/src/sync/git-adapter.ts
+++ b/src/sync/git-adapter.ts
@@ -31,6 +31,7 @@ export class GitSyncAdapter implements SyncAdapter {
   }
 
   private ensureMigrated(cortex: string): void {
+    fetchBranch(cortex);
     const files = listBranchFiles(cortex, '.jsonl');
     const hasNumbered = files.some(f => /^\d{6}\.jsonl$/.test(f));
     if (!hasNumbered) {
@@ -68,9 +69,6 @@ export class GitSyncAdapter implements SyncAdapter {
     const lastVersion = cursorStr ? parseInt(cursorStr, 10) : 0;
 
     // Ensure legacy memories.jsonl is migrated to bucketed format
-    // (fetchBranch happens inside appendAndCommit via pull --rebase,
-    // but we need fresh remote state for migration check and bucket determination)
-    fetchBranch(cortex);
     this.ensureMigrated(cortex);
 
     // Get memories created since last push
@@ -190,11 +188,10 @@ export class GitSyncAdapter implements SyncAdapter {
     for (const file of filesToRead) {
       const raw = readFileFromBranch(cortex, file);
       if (raw === null) {
-        // File failed to read (shouldn't happen after fetch) — stop advancing cursor
-        break;
+        // Transient read failure — skip this file but continue processing remaining
+        // files. Cursor won't advance past it, so it gets retried on next pull.
+        continue;
       }
-      // Advance cursor past this file even if empty (empty file = nothing to process,
-      // but we've confirmed it exists and was read — don't re-read it forever)
       lastReadFile = file;
       if (raw.trim()) {
         this.processMemories(cortex, raw, result);

--- a/src/sync/git-adapter.ts
+++ b/src/sync/git-adapter.ts
@@ -69,7 +69,12 @@ export class GitSyncAdapter implements SyncAdapter {
 
     // Single fetch, read file list once, pass to both migration check and bucket determination
     const branchFiles = listBranchFiles(cortex, '.jsonl');
-    this.ensureMigrated(cortex, branchFiles);
+    try {
+      this.ensureMigrated(cortex, branchFiles);
+    } catch (err) {
+      result.errors.push(`Migration failed: ${err instanceof Error ? err.message : String(err)}`);
+      return result;
+    }
 
     // Re-read after potential migration (migration changes the file list)
     const currentFiles = branchFiles.some(f => /^\d{6}\.jsonl$/.test(f))


### PR DESCRIPTION
## Summary

Splits the single `memories.jsonl` file into sequentially numbered ~500-line bucket files (`000001.jsonl`, `000002.jsonl`, etc.) for scalable git sync and fast agent onboarding.

- **Push**: determines target bucket file by counting lines in the latest. Creates next file when current hits ~500.
- **Pull onboarding**: fetches only the last N files based on `onboardingDepth` config (default 1500 = 3 files)
- **Pull incremental**: reads from `pull_file` cursor onward, skipping already-ingested files
- **Auto-migration**: legacy `memories.jsonl` renamed to `000001.jsonl` on first push
- **Legacy fallback**: pull reads `memories.jsonl` if no numbered files exist
- **New cortexes**: `createOrphanBranch` creates `000001.jsonl` instead of `memories.jsonl`
- **Config**: `bucketSize` (default 500) and `onboardingDepth` (default 1500) added to CortexConfig

### How concurrent writes work

Two agents both append to the same bucket file — git rebase merges the appends. If both create the same new file number, the second agent's push is rejected, rebase merges both, file goes slightly over 500. Next push creates the next file.

### What happens to existing large files

The legacy `memories.jsonl` becomes `000001.jsonl` as-is, regardless of size. New memories go to `000002.jsonl`. The oversized file ages out of the onboarding window as new buckets accumulate.

## Test plan

- [ ] Existing repo with `memories.jsonl`: first push renames to `000001.jsonl`
- [ ] New cortex: `createOrphanBranch` creates `000001.jsonl`
- [ ] Push after 500+ memories: creates `000002.jsonl`
- [ ] Fresh agent pull: fetches only last 3 files (default depth)
- [ ] Incremental pull: only reads new/changed files from cursor
- [ ] Legacy fallback: pull still works on repos with only `memories.jsonl`
- [ ] Build passes: `npm run build`

Note: End-to-end git testing was limited by a local repo config mismatch. The bucketing logic (file listing, line counting, bucket determination, migration) is implemented and builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)