### PR TITLE
Add `think memory add` command

### DIFF
--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -1,42 +1,110 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { getConfig } from '../lib/config.js';
-import { getMemories } from '../db/memory-queries.js';
+import { getMemories, insertMemory } from '../db/memory-queries.js';
 import { closeCortexDb } from '../db/engrams.js';
+import { getSyncAdapter } from '../sync/registry.js';
+import { validateEngramContent } from '../lib/sanitize.js';
 
-export const memoryCommand = new Command('memory')
-  .description('Show current memories from local store')
-  .option('--history', 'Show recent memory timeline')
-  .action(async (opts: { history?: boolean }) => {
+const addCommand = new Command('add')
+  .description('Add a memory directly, bypassing curation')
+  .argument('<message>', 'The memory content')
+  .option('--no-push', 'Skip pushing to remote after adding')
+  .option('--silent', 'Suppress output')
+  .action(async function (this: Command, message: string, opts: { push: boolean; silent?: boolean }) {
+    const globalOpts = this.optsWithGlobals() as { cortex?: string };
     const config = getConfig();
-    const cortex = config.cortex?.active;
+    const cortex = globalOpts.cortex ?? config.cortex?.active;
 
     if (!cortex) {
       console.error(chalk.red('No active cortex. Run: think cortex switch <name>'));
       process.exit(1);
     }
 
-    const memories = getMemories(cortex, { limit: opts.history ? 50 : undefined });
+    const author = config.cortex?.author ?? 'unknown';
 
-    if (memories.length === 0) {
-      console.log(chalk.dim('No memories yet. Run: think curate'));
-      closeCortexDb(cortex);
-      return;
-    }
-
-    if (opts.history) {
-      for (const m of memories.reverse()) {
-        const ts = m.ts.slice(0, 16).replace('T', ' ');
-        const preview = m.content.length > 80 ? m.content.slice(0, 80) + '...' : m.content;
-        console.log(`${chalk.gray(ts)}  ${chalk.dim(m.author + ':')} ${preview}`);
-      }
-    } else {
-      for (const m of memories) {
-        const ts = m.ts.slice(0, 16).replace('T', ' ');
-        console.log(`${chalk.gray(ts)}  ${chalk.dim(m.author + ':')} ${m.content}`);
+    // Validate and sanitize content
+    const validated = validateEngramContent(message);
+    message = validated.content;
+    if (!opts.silent && validated.warnings.length > 0) {
+      for (const w of validated.warnings) {
+        console.log(chalk.yellow(`  ⚠ ${w}`));
       }
     }
 
-    console.log(chalk.dim(`\n${memories.length} memories`));
+    const row = insertMemory(cortex, {
+      ts: new Date().toISOString(),
+      author,
+      content: message,
+      source_ids: [],
+    });
+
+    if (!opts.silent) {
+      const badge = chalk.cyan(`[${cortex}]`);
+      const ts = chalk.gray(row.ts.slice(0, 16).replace('T', ' '));
+      console.log(`${chalk.green('✓')} ${badge} memory added ${ts}`);
+      console.log(`  ${row.content}`);
+    }
+
+    // Auto-push unless --no-push
+    if (opts.push) {
+      const adapter = getSyncAdapter();
+      if (adapter?.isAvailable()) {
+        try {
+          const result = await adapter.push(cortex);
+          if (!opts.silent && result.pushed > 0) {
+            console.log(chalk.dim(`  Pushed ${result.pushed} memories to ${adapter.name}`));
+          }
+        } catch {
+          if (!opts.silent) {
+            console.log(chalk.dim('  Push skipped (remote unavailable) — will push on next sync'));
+          }
+        }
+      }
+    }
+
     closeCortexDb(cortex);
   });
+
+async function showMemories(opts: { history?: boolean }): Promise<void> {
+  const config = getConfig();
+  const cortex = config.cortex?.active;
+
+  if (!cortex) {
+    console.error(chalk.red('No active cortex. Run: think cortex switch <name>'));
+    process.exit(1);
+  }
+
+  const memories = getMemories(cortex, { limit: opts.history ? 50 : undefined });
+
+  if (memories.length === 0) {
+    console.log(chalk.dim('No memories yet. Run: think curate'));
+    closeCortexDb(cortex);
+    return;
+  }
+
+  if (opts.history) {
+    for (const m of memories.reverse()) {
+      const ts = m.ts.slice(0, 16).replace('T', ' ');
+      const preview = m.content.length > 80 ? m.content.slice(0, 80) + '...' : m.content;
+      console.log(`${chalk.gray(ts)}  ${chalk.dim(m.author + ':')} ${preview}`);
+    }
+  } else {
+    for (const m of memories) {
+      const ts = m.ts.slice(0, 16).replace('T', ' ');
+      console.log(`${chalk.gray(ts)}  ${chalk.dim(m.author + ':')} ${m.content}`);
+    }
+  }
+
+  console.log(chalk.dim(`\n${memories.length} memories`));
+  closeCortexDb(cortex);
+}
+
+export const memoryCommand = new Command('memory')
+  .description('Show current memories from local store')
+  .option('--history', 'Show recent memory timeline')
+  .action(async (opts: { history?: boolean }) => {
+    await showMemories(opts);
+  });
+
+memoryCommand.addCommand(addCommand);


### PR DESCRIPTION
## Summary
- Adds `think memory add <message>` subcommand for writing memories directly to the local store, bypassing curation
- Auto-pushes to remote by default (`--no-push` to skip, `--silent` for scripts)
- Input is sanitized through existing `validateEngramContent`
- `think memory` (no subcommand) continues to work as before, showing all memories

## Motivation
When ingesting pre-curated content (e.g., meeting transcript summaries), the existing paths don't fit:
- **Regular curation** may drop valid memories based on selectivity thresholds
- **Episode curation** collapses all engrams into a single narrative, losing distinct topics

`memory add` gives callers a direct path for content that's already been distilled and doesn't need a second opinion from the curator.

## Test plan
- [ ] `think memory add "test"` writes to local SQLite and pushes to git
- [ ] `think memory add --no-push "test"` writes locally only
- [ ] `think memory add --silent "test"` produces no output
- [ ] `think memory` (no subcommand) still shows all memories
- [ ] `think memory --history` still works
- [ ] Memory appears in `think recall` search results

🤖 Generated with [Claude Code](https://claude.com/claude-code)