### PR TITLE
feat: add --context and --decision flags to think sync

### DIFF
--- a/src/commands/log.ts
+++ b/src/commands/log.ts
@@ -52,8 +52,10 @@ export const syncCommand = new Command('sync')
   .option('-s, --source <source>', 'Source of the entry', 'manual')
   .option('-t, --tags <tags>', 'Comma-separated tags')
   .option('-e, --episode <key>', 'Tag this engram with an episode identifier')
+  .option('--context <json>', 'Attach structured JSON metadata to this engram')
+  .option('-d, --decision <text>', 'Record a decision (repeatable)', (val: string, prev: string[]) => [...prev, val], [] as string[])
   .option('--silent', 'Suppress output')
-  .action(function (this: Command, message: string, opts: { source: string; tags?: string; episode?: string; silent?: boolean }) {
+  .action(function (this: Command, message: string, opts: { source: string; tags?: string; episode?: string; context?: string; decision?: string[]; silent?: boolean }) {
     const globalOpts = this.optsWithGlobals() as { cortex?: string };
     const config = getConfig();
 
@@ -74,8 +76,20 @@ export const syncCommand = new Command('sync')
         }
       }
 
+      // Validate --context is valid JSON if provided
+      if (opts.context) {
+        try {
+          JSON.parse(opts.context);
+        } catch {
+          console.error(chalk.red('Error: --context must be valid JSON'));
+          process.exitCode = 1;
+          return;
+        }
+      }
+
       // Route to cortex engram DB
-      const engram = insertEngram(cortex, { content: message, episodeKey: opts.episode });
+      const decisions = opts.decision?.length ? opts.decision : undefined;
+      const engram = insertEngram(cortex, { content: message, episodeKey: opts.episode, context: opts.context, decisions });
 
       if (!opts.silent) {
         const badge = chalk.cyan(`[${cortex}]`);

--- a/src/db/engram-queries.ts
+++ b/src/db/engram-queries.ts
@@ -10,12 +10,16 @@ export interface Engram {
   promoted: number | null;
   deleted_at: string | null;
   episode_key: string | null;
+  context: string | null;
+  decisions: string | null;
 }
 
 export interface InsertEngramParams {
   content: string;
   expiresInDays?: number;
   episodeKey?: string;
+  context?: string;
+  decisions?: string[];
 }
 
 export function insertEngram(cortexName: string, params: InsertEngramParams): Engram {
@@ -27,12 +31,14 @@ export function insertEngram(cortexName: string, params: InsertEngramParams): En
   const expires_at = new Date(now.getTime() + expiresInDays * 86400000).toISOString();
 
   const episodeKey = params.episodeKey ?? null;
+  const context = params.context ?? null;
+  const decisions = params.decisions?.length ? JSON.stringify(params.decisions) : null;
 
   db.prepare(
-    `INSERT INTO engrams (id, content, created_at, expires_at, episode_key) VALUES (?, ?, ?, ?, ?)`
-  ).run(id, params.content, created_at, expires_at, episodeKey);
+    `INSERT INTO engrams (id, content, created_at, expires_at, episode_key, context, decisions) VALUES (?, ?, ?, ?, ?, ?, ?)`
+  ).run(id, params.content, created_at, expires_at, episodeKey, context, decisions);
 
-  return { id, content: params.content, created_at, expires_at, evaluated_at: null, promoted: null, deleted_at: null, episode_key: episodeKey };
+  return { id, content: params.content, created_at, expires_at, evaluated_at: null, promoted: null, deleted_at: null, episode_key: episodeKey, context, decisions };
 }
 
 export function getPendingEngrams(cortexName: string): Engram[] {

--- a/src/db/engrams.ts
+++ b/src/db/engrams.ts
@@ -104,6 +104,13 @@ const migrations: Migration[] = [
       db.exec('CREATE INDEX IF NOT EXISTS idx_memories_episode_key ON memories(episode_key);');
     },
   },
+  {
+    version: 4,
+    up: (db) => {
+      db.exec('ALTER TABLE engrams ADD COLUMN context TEXT;');
+      db.exec('ALTER TABLE engrams ADD COLUMN decisions TEXT;');
+    },
+  },
 ];
 
 /** Returns the per-cortex SQLite connection (holds engrams, memories, longterm_summary, and sync_cursors tables) */

--- a/src/lib/curator.ts
+++ b/src/lib/curator.ts
@@ -31,6 +31,7 @@ Your task:
    - Blockers encountered or resolved
    - Clusters — multiple events around the same topic signal importance
    - Weight — urgency, frustration, or surprise in the language suggests significance
+   - Decisions — events with explicit decisions attached are high-signal and should almost always be promoted. Preserve the decision rationale in the memory.
 4. Routine, administrative, or low-signal events should be dropped.
    Dropping is correct, not a failure.
 
@@ -120,7 +121,21 @@ export function assembleCurationPrompt(params: {
   const curatorMdText = params.curatorMd ?? '(none provided)';
 
   const engramsText = params.pendingEngrams
-    .map(e => `- [${e.created_at}] (id: ${e.id}) ${e.content}`)
+    .map(e => {
+      let line = `- [${e.created_at}] (id: ${e.id}) ${e.content}`;
+      if (e.decisions) {
+        try {
+          const decisions = JSON.parse(e.decisions) as string[];
+          if (decisions.length > 0) {
+            line += `\n  Decisions: ${decisions.map(d => `"${d}"`).join('; ')}`;
+          }
+        } catch { /* skip malformed */ }
+      }
+      if (e.context) {
+        line += `\n  Context: ${e.context}`;
+      }
+      return line;
+    })
     .join('\n');
 
   // Build user message with data wrapped in delimiter tags
@@ -310,7 +325,21 @@ export function assembleEpisodeCurationPrompt(params: {
   author: string;
 }): StructuredPrompt {
   const engramsText = params.pendingEngrams
-    .map(e => `- [${e.created_at}] ${e.content}`)
+    .map(e => {
+      let line = `- [${e.created_at}] ${e.content}`;
+      if (e.decisions) {
+        try {
+          const decisions = JSON.parse(e.decisions) as string[];
+          if (decisions.length > 0) {
+            line += `\n  Decisions: ${decisions.map(d => `"${d}"`).join('; ')}`;
+          }
+        } catch { /* skip malformed */ }
+      }
+      if (e.context) {
+        line += `\n  Context: ${e.context}`;
+      }
+      return line;
+    })
     .join('\n');
 
   const sections = [


### PR DESCRIPTION
## Summary

- Adds `--context <json>` flag to attach structured JSON metadata to engrams
- Adds `-d, --decision <text>` repeatable flag to record decisions alongside engrams
- Migration v4 adds `context` and `decisions` columns to the engrams table
- Curation system prompt updated to treat decisions as high-signal (almost always promoted)
- Both standard and episode curation prompts surface decisions and context alongside engram content

Prerequisite for ANGL-2034 (HiveDB for review bot).

## Test plan

- [x] `think sync "test" --context '{"persona":"cobel"}' -d "decision one" -d "decision two"` — stores both fields
- [x] `think sync "test" --context 'bad json'` — rejects with error
- [x] Verified data in SQLite: context stored as raw JSON string, decisions as JSON array

🤖 Generated with [Claude Code](https://claude.com/claude-code)