### PR TITLE
feat: add decisions as first-class field on memories

### DIFF
--- a/src/commands/curate.ts
+++ b/src/commands/curate.ts
@@ -294,6 +294,7 @@ export const curateCommand = new Command('curate')
           author: entry.author,
           content: entry.content,
           source_ids: entry.source_ids,
+          decisions: entry.decisions,
         });
       }
     }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -6,19 +6,21 @@ import chalk from 'chalk';
 
 const CLAUDE_MD_SECTION = `# Work Logging
 
-**After every commit, push, PR, deploy, Linear update, or non-trivial tool-assisted action, immediately run \`think sync\` before responding to the user's next request. This is not optional.**
+**After every commit, push, PR, deploy, Linear update, non-trivial tool-assisted action, or decision made in conversation, immediately run \`think sync\` before responding to the user's next request. This is not optional.**
 
 \`\`\`
 think sync "concise summary of what was done" --silent
+think sync "explored X, decided against it" --decision "Decided against X because Y" --silent
 \`\`\`
 
-**Do log:** features built, bugs fixed, PRs created/reviewed, deploys, config changes, refactors completed, investigations concluded, decisions made, documents written, Linear/external system updates
+**Do log:** features built, bugs fixed, PRs created/reviewed, deploys, config changes, refactors completed, investigations concluded, decisions made (including decisions to NOT do something), documents written, Linear/external system updates
 
 **Don't log:** clarifying questions, exploration, failed attempts, reading code, debugging dead ends, conversation that didn't produce an outcome
 
 **How to log:**
 - One entry per completed task, not per tool call or file edit
 - Frame as accomplishments: "Implemented X", "Fixed Y", "Reviewed Z"
+- Decisions to not pursue something are logged as: "Decided against X because Y"
 - If a task spans the whole session, log at the end
 - If multiple distinct things were done, log each separately
 - Keep entries concise but specific enough to be useful in a weekly summary

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -11,7 +11,8 @@ const addCommand = new Command('add')
   .argument('<message>', 'The memory content')
   .option('--no-push', 'Skip pushing to remote after adding')
   .option('--silent', 'Suppress output')
-  .action(async function (this: Command, message: string, opts: { push: boolean; silent?: boolean }) {
+  .option('-d, --decision <text>', 'Record a decision (repeatable)', (val: string, prev: string[]) => [...prev, val], [] as string[])
+  .action(async function (this: Command, message: string, opts: { push: boolean; silent?: boolean; decision: string[] }) {
     const globalOpts = this.optsWithGlobals() as { cortex?: string };
     const config = getConfig();
     const cortex = globalOpts.cortex ?? config.cortex?.active;
@@ -37,6 +38,7 @@ const addCommand = new Command('add')
       author,
       content: message,
       source_ids: [],
+      decisions: opts.decision.length > 0 ? opts.decision : undefined,
     });
 
     if (!opts.silent) {

--- a/src/commands/recall.ts
+++ b/src/commands/recall.ts
@@ -37,6 +37,14 @@ export const recallCommand = new Command('recall')
         for (const m of recentMemories) {
           const ts = m.ts.slice(0, 16).replace('T', ' ');
           console.log(`  ${chalk.gray(ts)} ${chalk.dim(m.author + ':')} ${m.content}`);
+          if (m.decisions) {
+            try {
+              const decisions = JSON.parse(m.decisions) as string[];
+              for (const d of decisions) {
+                console.log(`    ${chalk.yellow('⚡')} ${chalk.yellow(d)}`);
+              }
+            } catch { /* skip malformed */ }
+          }
         }
         console.log();
       }
@@ -72,6 +80,14 @@ export const recallCommand = new Command('recall')
       for (const m of matchingMemories) {
         const ts = m.ts.slice(0, 16).replace('T', ' ');
         console.log(`  ${chalk.gray(ts)} ${chalk.dim(m.author + ':')} ${m.content}`);
+        if (m.decisions) {
+          try {
+            const decisions = JSON.parse(m.decisions) as string[];
+            for (const d of decisions) {
+              console.log(`    ${chalk.yellow('⚡')} ${chalk.yellow(d)}`);
+            }
+          } catch { /* skip malformed */ }
+        }
       }
       console.log();
     } else {

--- a/src/commands/recall.ts
+++ b/src/commands/recall.ts
@@ -3,7 +3,18 @@ import chalk from 'chalk';
 import { getConfig } from '../lib/config.js';
 import { searchEngrams } from '../db/engram-queries.js';
 import { searchMemories, getLongtermSummary } from '../db/memory-queries.js';
+import type { MemoryRow } from '../db/memory-queries.js';
 import { closeCortexDb } from '../db/engrams.js';
+
+function printDecisions(m: MemoryRow): void {
+  if (!m.decisions) return;
+  try {
+    const decisions = JSON.parse(m.decisions) as string[];
+    for (const d of decisions) {
+      console.log(`    ${chalk.yellow('⚡')} ${chalk.yellow(d)}`);
+    }
+  } catch { /* skip malformed */ }
+}
 
 export const recallCommand = new Command('recall')
   .argument('<query>', 'What to recall')
@@ -37,14 +48,7 @@ export const recallCommand = new Command('recall')
         for (const m of recentMemories) {
           const ts = m.ts.slice(0, 16).replace('T', ' ');
           console.log(`  ${chalk.gray(ts)} ${chalk.dim(m.author + ':')} ${m.content}`);
-          if (m.decisions) {
-            try {
-              const decisions = JSON.parse(m.decisions) as string[];
-              for (const d of decisions) {
-                console.log(`    ${chalk.yellow('⚡')} ${chalk.yellow(d)}`);
-              }
-            } catch { /* skip malformed */ }
-          }
+          printDecisions(m);
         }
         console.log();
       }
@@ -80,14 +84,7 @@ export const recallCommand = new Command('recall')
       for (const m of matchingMemories) {
         const ts = m.ts.slice(0, 16).replace('T', ' ');
         console.log(`  ${chalk.gray(ts)} ${chalk.dim(m.author + ':')} ${m.content}`);
-        if (m.decisions) {
-          try {
-            const decisions = JSON.parse(m.decisions) as string[];
-            for (const d of decisions) {
-              console.log(`    ${chalk.yellow('⚡')} ${chalk.yellow(d)}`);
-            }
-          } catch { /* skip malformed */ }
-        }
+        printDecisions(m);
       }
       console.log();
     } else {

--- a/src/db/engrams.ts
+++ b/src/db/engrams.ts
@@ -111,6 +111,12 @@ const migrations: Migration[] = [
       db.exec('ALTER TABLE engrams ADD COLUMN decisions TEXT;');
     },
   },
+  {
+    version: 5,
+    up: (db) => {
+      db.exec('ALTER TABLE memories ADD COLUMN decisions TEXT;');
+    },
+  },
 ];
 
 /** Returns the per-cortex SQLite connection (holds engrams, memories, longterm_summary, and sync_cursors tables) */

--- a/src/db/memory-queries.ts
+++ b/src/db/memory-queries.ts
@@ -11,6 +11,7 @@ export interface MemoryRow {
   deleted_at: string | null;
   sync_version: number;
   episode_key: string | null;
+  decisions: string | null;
 }
 
 export interface InsertMemoryParams {
@@ -21,6 +22,7 @@ export interface InsertMemoryParams {
   source_ids?: string[];
   deleted_at?: string | null;
   episode_key?: string;
+  decisions?: string[];
 }
 
 export function insertMemory(cortexName: string, params: InsertMemoryParams): MemoryRow {
@@ -30,12 +32,13 @@ export function insertMemory(cortexName: string, params: InsertMemoryParams): Me
   const sourceIds = JSON.stringify(params.source_ids ?? []);
 
   const episodeKey = params.episode_key ?? null;
+  const decisions = params.decisions?.length ? JSON.stringify(params.decisions) : null;
 
   // Atomic sync_version assignment via subquery — no race between read and write
   db.prepare(
-    `INSERT INTO memories (id, ts, author, content, source_ids, created_at, deleted_at, sync_version, episode_key)
-     VALUES (?, ?, ?, ?, ?, ?, ?, (SELECT COALESCE(MAX(sync_version), 0) + 1 FROM memories), ?)`
-  ).run(id, params.ts, params.author, params.content, sourceIds, now, params.deleted_at ?? null, episodeKey);
+    `INSERT INTO memories (id, ts, author, content, source_ids, created_at, deleted_at, sync_version, episode_key, decisions)
+     VALUES (?, ?, ?, ?, ?, ?, ?, (SELECT COALESCE(MAX(sync_version), 0) + 1 FROM memories), ?, ?)`
+  ).run(id, params.ts, params.author, params.content, sourceIds, now, params.deleted_at ?? null, episodeKey, decisions);
 
   const row = db.prepare('SELECT * FROM memories WHERE id = ?').get(id) as unknown as MemoryRow;
   return row;

--- a/src/lib/curator.ts
+++ b/src/lib/curator.ts
@@ -11,6 +11,7 @@ export interface MemoryEntry {
   source_ids: string[];
   episode_key?: string;
   deleted_at?: string;
+  decisions?: string[];
 }
 
 export interface StructuredPrompt {
@@ -43,9 +44,12 @@ Output format — return a JSON array of entries to append:
     "ts": "ISO 8601 timestamp",
     "author": "contributor name",
     "content": "the memory — specific, factual, written for an agent",
-    "source_ids": ["id1", "id2"]
+    "source_ids": ["id1", "id2"],
+    "decisions": ["decision text 1", "decision text 2"]
   }
 ]
+
+The "decisions" field is optional. Include it when the source engrams contain explicit decisions. Each decision should be a concise statement of what was decided and why. Omit the field (or use an empty array) when there are no decisions.
 
 If nothing warrants a new entry, return an empty array: []
 
@@ -188,6 +192,9 @@ export function parseMemoriesJsonl(content: string): MemoryEntry[] {
     try {
       const parsed = JSON.parse(line);
       if (parsed && typeof parsed.content === 'string') {
+        const decisions = Array.isArray(parsed.decisions)
+          ? parsed.decisions.filter((d: unknown): d is string => typeof d === 'string' && d.length > 0)
+          : [];
         entries.push({
           ts: parsed.ts ?? '',
           author: parsed.author ?? 'unknown',
@@ -195,6 +202,7 @@ export function parseMemoriesJsonl(content: string): MemoryEntry[] {
           source_ids: Array.isArray(parsed.source_ids) ? parsed.source_ids : [],
           ...(parsed.episode_key ? { episode_key: parsed.episode_key } : {}),
           ...(parsed.deleted_at ? { deleted_at: parsed.deleted_at } : {}),
+          ...(decisions.length > 0 ? { decisions } : {}),
         });
       }
     } catch {
@@ -246,11 +254,16 @@ export async function runCuration(curationPrompt: StructuredPrompt): Promise<Mem
     if (typeof obj.content !== 'string' || !obj.content) {
       throw new Error(`Curation entry ${i} is missing content`);
     }
+    const decisions = Array.isArray(obj.decisions)
+      ? obj.decisions.filter((d): d is string => typeof d === 'string' && d.length > 0)
+      : [];
+
     return {
       ts: typeof obj.ts === 'string' ? obj.ts : new Date().toISOString(),
       author: typeof obj.author === 'string' ? obj.author : 'unknown',
       content: obj.content,
       source_ids: Array.isArray(obj.source_ids) ? obj.source_ids.filter((id): id is string => typeof id === 'string') : [],
+      ...(decisions.length > 0 ? { decisions } : {}),
     };
   });
 

--- a/src/sync/git-adapter.ts
+++ b/src/sync/git-adapter.ts
@@ -89,15 +89,19 @@ export class GitSyncAdapter implements SyncAdapter {
     // Determine which bucket file to write to
     const targetFile = this.determineBucketFile(cortex, currentFiles);
 
-    // Format as JSONL lines (include episode_key and deleted_at when present)
-    const newLines = newMemories.map(m => JSON.stringify({
-      ts: m.ts,
-      author: m.author,
-      content: m.content,
-      source_ids: JSON.parse(m.source_ids),
-      ...(m.episode_key ? { episode_key: m.episode_key } : {}),
-      ...(m.deleted_at ? { deleted_at: m.deleted_at } : {}),
-    }));
+    // Format as JSONL lines (include episode_key, deleted_at, and decisions when present)
+    const newLines = newMemories.map(m => {
+      const decisions = m.decisions ? JSON.parse(m.decisions) as string[] : [];
+      return JSON.stringify({
+        ts: m.ts,
+        author: m.author,
+        content: m.content,
+        source_ids: JSON.parse(m.source_ids),
+        ...(m.episode_key ? { episode_key: m.episode_key } : {}),
+        ...(m.deleted_at ? { deleted_at: m.deleted_at } : {}),
+        ...(decisions.length > 0 ? { decisions } : {}),
+      });
+    });
 
     const config = getConfig();
     const commitMsg = `curate: ${config.cortex?.author ?? 'unknown'}, ${newMemories.length} memories`;
@@ -145,6 +149,7 @@ export class GitSyncAdapter implements SyncAdapter {
         content: sanitizedContent,
         source_ids: m.source_ids,
         episode_key: m.episode_key,
+        decisions: m.decisions,
       });
       if (wasInserted) result.pulled++;
     }

--- a/src/sync/git-adapter.ts
+++ b/src/sync/git-adapter.ts
@@ -91,7 +91,10 @@ export class GitSyncAdapter implements SyncAdapter {
 
     // Format as JSONL lines (include episode_key, deleted_at, and decisions when present)
     const newLines = newMemories.map(m => {
-      const decisions = m.decisions ? JSON.parse(m.decisions) as string[] : [];
+      let decisions: string[] = [];
+      if (m.decisions) {
+        try { decisions = JSON.parse(m.decisions) as string[]; } catch { /* skip malformed */ }
+      }
       return JSON.stringify({
         ts: m.ts,
         author: m.author,


### PR DESCRIPTION
## Summary

- Decisions were only stored on engrams (via `think sync --decision`) but lost when promoted to memories during curation
- This adds `decisions` as a first-class column on the memories table, carried through the full lifecycle: insertion, curation, sync, and display
- `think memory add` now accepts `--decision` flag (repeatable) for direct memory insertion with decisions

## Changes

- **Migration v5**: adds `decisions TEXT` column to memories table
- **`memory add` command**: new `-d, --decision <text>` flag (repeatable)
- **Curation**: LLM prompt updated to emit decisions; `runCuration` parses them; `curate` command passes them through to `insertMemory`
- **Git sync**: decisions serialized in JSONL on push, deserialized on pull
- **Recall**: decisions displayed with ⚡ indicator under matching memories
- **init template**: CLAUDE.md template updated with decision logging guidance

## Test plan

- [x] `think memory add "test" --decision "decided X"` stores decisions in SQLite
- [x] `think recall "test"` displays decisions with ⚡ indicator
- [x] Build passes cleanly
- [ ] Curation promotes engram decisions to memory decisions (requires engrams with decisions + LLM call)
- [ ] Git sync round-trip: push memories with decisions, pull on another device, verify decisions present

🤖 Generated with [Claude Code](https://claude.com/claude-code)