### PR TITLE
fix: show decisions in think memory output

### DIFF
--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import chalk from 'chalk';
 import { getConfig } from '../lib/config.js';
 import { getMemories, insertMemory } from '../db/memory-queries.js';
+import { printDecisions } from './recall.js';
 import { closeCortexDb } from '../db/engrams.js';
 import { getSyncAdapter } from '../sync/registry.js';
 import { validateEngramContent } from '../lib/sanitize.js';
@@ -90,11 +91,13 @@ async function showMemories(opts: { history?: boolean }): Promise<void> {
       const ts = m.ts.slice(0, 16).replace('T', ' ');
       const preview = m.content.length > 80 ? m.content.slice(0, 80) + '...' : m.content;
       console.log(`${chalk.gray(ts)}  ${chalk.dim(m.author + ':')} ${preview}`);
+      printDecisions(m);
     }
   } else {
     for (const m of memories) {
       const ts = m.ts.slice(0, 16).replace('T', ' ');
       console.log(`${chalk.gray(ts)}  ${chalk.dim(m.author + ':')} ${m.content}`);
+      printDecisions(m);
     }
   }
 

--- a/src/commands/recall.ts
+++ b/src/commands/recall.ts
@@ -6,7 +6,7 @@ import { searchMemories, getLongtermSummary } from '../db/memory-queries.js';
 import type { MemoryRow } from '../db/memory-queries.js';
 import { closeCortexDb } from '../db/engrams.js';
 
-function printDecisions(m: MemoryRow): void {
+export function printDecisions(m: MemoryRow): void {
   if (!m.decisions) return;
   try {
     const decisions = JSON.parse(m.decisions) as string[];


### PR DESCRIPTION
## Summary

- `think memory` and `think memory --history` were missing decision display — only `think recall` showed the ⚡ indicators
- Export `printDecisions` from recall.ts, import and use in both memory display paths

## Test plan

- [x] `think memory` shows ⚡ decisions under memories that have them
- [x] `think memory --history` shows ⚡ decisions
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)