### PR TITLE
feat: auto-curation via LaunchAgent + --if-idle decision logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "think",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "think",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.98",
         "chalk": "^5.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-think",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "type": "module",
   "description": "Local-first CLI that gives AI agents persistent, curated memory",
   "bin": {

--- a/src/commands/config-cmd.ts
+++ b/src/commands/config-cmd.ts
@@ -12,6 +12,8 @@ const ALLOWED_KEYS = new Set([
   'cortex.repo',
   'cortex.active',
   'cortex.engramTTLDays',
+  'cortex.idleWindowMinutes',
+  'cortex.staleWindowMinutes',
   'paused',
 ]);
 

--- a/src/commands/cortex.ts
+++ b/src/commands/cortex.ts
@@ -7,6 +7,7 @@ import { getCortexDb, closeCortexDb } from '../db/engrams.js';
 import { getMemoryCount, getSyncCursor } from '../db/memory-queries.js';
 import { getEngramsDir } from '../lib/paths.js';
 import { getSyncAdapter } from '../sync/registry.js';
+import { installAgent, uninstallAgent, getAgentStatus } from '../lib/auto-curate.js';
 
 function prompt(question: string, defaultValue?: string): Promise<string> {
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
@@ -332,3 +333,56 @@ cortexCommand.addCommand(new Command('status')
 
     closeCortexDb(cortex);
   }));
+
+// think cortex auto-curate — scheduled background curation
+const autoCurateCommand = new Command('auto-curate')
+  .description('Manage scheduled background curation (macOS LaunchAgent)');
+
+autoCurateCommand.addCommand(new Command('enable')
+  .description('Install a LaunchAgent that runs `think curate --if-idle` every 5 minutes')
+  .option('--interval <seconds>', 'Scheduler cadence in seconds (default 300)', (v) => parseInt(v, 10))
+  .action((opts: { interval?: number }) => {
+    try {
+      const { label, plistPath } = installAgent({ intervalSeconds: opts.interval });
+      console.log(chalk.green('✓') + ` Auto-curation enabled`);
+      console.log(chalk.dim(`  Label: ${label}`));
+      console.log(chalk.dim(`  Plist: ${plistPath}`));
+      if (process.env.THINK_HOME) {
+        console.log(chalk.dim(`  THINK_HOME: ${process.env.THINK_HOME}`));
+      }
+    } catch (err) {
+      console.error(chalk.red(err instanceof Error ? err.message : String(err)));
+      process.exit(1);
+    }
+  }));
+
+autoCurateCommand.addCommand(new Command('disable')
+  .description('Remove the auto-curation LaunchAgent for this workspace')
+  .action(() => {
+    const { removed, plistPath } = uninstallAgent();
+    if (removed) {
+      console.log(chalk.green('✓') + ` Auto-curation disabled (${plistPath})`);
+    } else {
+      console.log(chalk.dim(`No auto-curation agent installed (${plistPath})`));
+    }
+  }));
+
+autoCurateCommand.addCommand(new Command('status')
+  .description('Show auto-curation scheduler status')
+  .action(() => {
+    const s = getAgentStatus();
+    console.log(`Label:     ${chalk.cyan(s.label)}`);
+    console.log(`Installed: ${s.installed ? chalk.green('yes') : chalk.dim('no')}`);
+    console.log(`Loaded:    ${s.loaded ? chalk.green('yes') : chalk.dim('no')}`);
+    if (s.intervalSeconds) {
+      console.log(`Interval:  ${s.intervalSeconds}s`);
+    }
+    console.log(`Plist:     ${s.plistPath}`);
+    if (s.lastRunAt) {
+      console.log(`Last log:  ${s.lastRunAt.toISOString()}`);
+    } else {
+      console.log(`Last log:  ${chalk.dim('(no log file yet)')}`);
+    }
+  }));
+
+cortexCommand.addCommand(autoCurateCommand);

--- a/src/commands/curate.ts
+++ b/src/commands/curate.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import readline from 'node:readline';
 import chalk from 'chalk';
 import { getConfig } from '../lib/config.js';
+import type { CortexConfig } from '../lib/config.js';
 import { getPendingEngrams, getPendingEpisodeEngrams, markPromoted, markPurged, pruneExpiredEngrams } from '../db/engram-queries.js';
 import { getMemories, getLongtermSummary, setLongtermSummary, insertMemory, getMemoryByEpisodeKey, tombstoneMemory } from '../db/memory-queries.js';
 import { closeCortexDb } from '../db/engrams.js';
@@ -22,16 +23,38 @@ export const curateCommand = new Command('curate')
   .option('--dry-run', 'Preview what would be committed without saving')
   .option('--consolidate', 'Run long-term memory consolidation only (no curation)')
   .option('--episode <key>', 'Curate a specific episode into a narrative memory')
-  .action(async (opts: { dryRun?: boolean; consolidate?: boolean; episode?: string }) => {
+  .option('--if-idle', 'Only curate if the user appears idle (used by auto-curation scheduler)')
+  .action(async (opts: { dryRun?: boolean; consolidate?: boolean; episode?: string; ifIdle?: boolean }) => {
     const config = getConfig();
     const cortex = config.cortex?.active;
 
     if (!cortex) {
+      if (opts.ifIdle) {
+        // Silent no-op when the scheduler fires with no cortex configured
+        return;
+      }
       console.error(chalk.red('No active cortex. Run: think cortex switch <name>'));
       process.exit(1);
     }
 
     const author = config.cortex!.author;
+
+    // --if-idle: bail early unless conditions are right. The scheduler fires
+    // on a fixed cadence, so most firings should exit here in milliseconds.
+    // Skip the check for explicit episode/consolidate runs — those are manual.
+    if (opts.ifIdle && !opts.episode && !opts.consolidate) {
+      const shouldRun = shouldRunIdleCuration(cortex, config.cortex);
+      if (!shouldRun.run) {
+        if (process.env.THINK_IDLE_DEBUG) {
+          console.log(chalk.dim(`[auto-curate] skipped: ${shouldRun.reason}`));
+        }
+        closeCortexDb(cortex);
+        return;
+      }
+      if (process.env.THINK_IDLE_DEBUG) {
+        console.log(chalk.dim(`[auto-curate] running: ${shouldRun.reason}`));
+      }
+    }
 
     // 0. Sync: pull latest memories from remote before curation
     const adapter = getSyncAdapter();
@@ -351,3 +374,43 @@ export const curateCommand = new Command('curate')
 
     closeCortexDb(cortex);
   });
+
+const DEFAULT_IDLE_WINDOW_MINUTES = 3;
+const DEFAULT_STALE_WINDOW_MINUTES = 60;
+
+// Decide whether an auto-curation run should proceed. Returns a reason
+// string either way — useful for --if-idle telemetry and debugging.
+function shouldRunIdleCuration(
+  cortex: string,
+  cortexConfig: CortexConfig | undefined,
+): { run: boolean; reason: string } {
+  const pending = getPendingEngrams(cortex);
+
+  if (pending.length === 0) {
+    return { run: false, reason: 'no pending engrams' };
+  }
+
+  const idleMinutes = cortexConfig?.idleWindowMinutes ?? DEFAULT_IDLE_WINDOW_MINUTES;
+  const staleMinutes = cortexConfig?.staleWindowMinutes ?? DEFAULT_STALE_WINDOW_MINUTES;
+  const now = Date.now();
+
+  // pending is ordered created_at ASC — oldest first, newest last.
+  const oldest = pending[0];
+  const newest = pending[pending.length - 1];
+  const oldestAgeMin = (now - new Date(oldest.created_at).getTime()) / 60000;
+  const newestAgeMin = (now - new Date(newest.created_at).getTime()) / 60000;
+
+  // Staleness cap wins: if the oldest engram is too old, curate regardless
+  // of how recently the user synced.
+  if (oldestAgeMin >= staleMinutes) {
+    return { run: true, reason: `staleness cap hit (oldest pending ${oldestAgeMin.toFixed(1)}min old)` };
+  }
+
+  // Otherwise, respect the idle window — if the user is still actively
+  // syncing, let the burst settle.
+  if (newestAgeMin < idleMinutes) {
+    return { run: false, reason: `still active (newest engram ${newestAgeMin.toFixed(1)}min old, idle threshold ${idleMinutes}min)` };
+  }
+
+  return { run: true, reason: `idle (${pending.length} pending, newest ${newestAgeMin.toFixed(1)}min old)` };
+}

--- a/src/lib/auto-curate.ts
+++ b/src/lib/auto-curate.ts
@@ -1,0 +1,187 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import { getThinkDir } from './paths.js';
+
+const DEFAULT_INTERVAL_SECONDS = 300; // 5 minutes
+
+function getHome(): string {
+  const home = process.env.HOME;
+  if (!home) throw new Error('HOME environment variable is not set');
+  return home;
+}
+
+function getLaunchAgentsDir(): string {
+  return path.join(getHome(), 'Library', 'LaunchAgents');
+}
+
+// Derive a stable label suffix from THINK_HOME so workspace-specific plists
+// don't collide. Defaults to 'default' when THINK_HOME is unset.
+export function getAgentLabel(): string {
+  const thinkHome = process.env.THINK_HOME;
+  if (!thinkHome) return 'ai.openthink.curate.default';
+  const hash = crypto.createHash('sha1').update(thinkHome).digest('hex').slice(0, 8);
+  return `ai.openthink.curate.${hash}`;
+}
+
+export function getPlistPath(label: string = getAgentLabel()): string {
+  return path.join(getLaunchAgentsDir(), `${label}.plist`);
+}
+
+export function getLogPath(): string {
+  return path.join(getThinkDir(), 'auto-curate.log');
+}
+
+function resolveThinkBinary(): string {
+  // Prefer the currently-running think binary so the scheduler uses the same
+  // version the user installed (not a stale path).
+  const arg1 = process.argv[1];
+  if (arg1 && fs.existsSync(arg1)) return arg1;
+  throw new Error('Could not resolve think binary path');
+}
+
+function resolveNodeBinary(): string {
+  return process.execPath;
+}
+
+interface PlistOptions {
+  label: string;
+  nodePath: string;
+  thinkPath: string;
+  thinkHome: string | undefined;
+  intervalSeconds: number;
+  logPath: string;
+}
+
+function renderPlist(opts: PlistOptions): string {
+  const envBlock = opts.thinkHome
+    ? `    <key>EnvironmentVariables</key>
+    <dict>
+      <key>THINK_HOME</key>
+      <string>${escapeXml(opts.thinkHome)}</string>
+    </dict>
+`
+    : '';
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>${escapeXml(opts.label)}</string>
+    <key>ProgramArguments</key>
+    <array>
+      <string>${escapeXml(opts.nodePath)}</string>
+      <string>${escapeXml(opts.thinkPath)}</string>
+      <string>curate</string>
+      <string>--if-idle</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>${opts.intervalSeconds}</integer>
+    <key>RunAtLoad</key>
+    <false/>
+${envBlock}    <key>StandardOutPath</key>
+    <string>${escapeXml(opts.logPath)}</string>
+    <key>StandardErrorPath</key>
+    <string>${escapeXml(opts.logPath)}</string>
+  </dict>
+</plist>
+`;
+}
+
+function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+export interface InstallOptions {
+  intervalSeconds?: number;
+}
+
+export function installAgent(opts: InstallOptions = {}): { label: string; plistPath: string } {
+  if (process.platform !== 'darwin') {
+    throw new Error('auto-curate install currently supports macOS only. For Linux, run `think curate --if-idle` from cron or systemd.');
+  }
+
+  const label = getAgentLabel();
+  const plistPath = getPlistPath(label);
+  const agentsDir = getLaunchAgentsDir();
+
+  fs.mkdirSync(agentsDir, { recursive: true });
+  fs.mkdirSync(getThinkDir(), { recursive: true });
+
+  const plist = renderPlist({
+    label,
+    nodePath: resolveNodeBinary(),
+    thinkPath: resolveThinkBinary(),
+    thinkHome: process.env.THINK_HOME,
+    intervalSeconds: opts.intervalSeconds ?? DEFAULT_INTERVAL_SECONDS,
+    logPath: getLogPath(),
+  });
+
+  fs.writeFileSync(plistPath, plist, { mode: 0o644 });
+
+  // Reload if already loaded (idempotent install); ignore failure if not loaded yet.
+  try { execFileSync('launchctl', ['unload', plistPath], { stdio: 'ignore' }); } catch { /* not loaded */ }
+  execFileSync('launchctl', ['load', plistPath], { stdio: 'ignore' });
+
+  return { label, plistPath };
+}
+
+export function uninstallAgent(): { removed: boolean; plistPath: string } {
+  const plistPath = getPlistPath();
+  if (!fs.existsSync(plistPath)) {
+    return { removed: false, plistPath };
+  }
+  if (process.platform === 'darwin') {
+    try { execFileSync('launchctl', ['unload', plistPath], { stdio: 'ignore' }); } catch { /* not loaded */ }
+  }
+  fs.unlinkSync(plistPath);
+  return { removed: true, plistPath };
+}
+
+export interface AgentStatus {
+  installed: boolean;
+  label: string;
+  plistPath: string;
+  loaded: boolean;
+  lastRunAt: Date | null;
+  intervalSeconds: number | null;
+}
+
+export function getAgentStatus(): AgentStatus {
+  const label = getAgentLabel();
+  const plistPath = getPlistPath(label);
+  const installed = fs.existsSync(plistPath);
+
+  let loaded = false;
+  let intervalSeconds: number | null = null;
+  if (installed && process.platform === 'darwin') {
+    try {
+      const out = execFileSync('launchctl', ['list', label], { stdio: ['ignore', 'pipe', 'ignore'] }).toString();
+      loaded = out.trim().length > 0;
+    } catch {
+      loaded = false;
+    }
+    try {
+      const plist = fs.readFileSync(plistPath, 'utf-8');
+      const match = plist.match(/<key>StartInterval<\/key>\s*<integer>(\d+)<\/integer>/);
+      if (match) intervalSeconds = parseInt(match[1], 10);
+    } catch { /* ignore */ }
+  }
+
+  let lastRunAt: Date | null = null;
+  const logPath = getLogPath();
+  if (fs.existsSync(logPath)) {
+    try {
+      const stat = fs.statSync(logPath);
+      lastRunAt = stat.mtime;
+    } catch { /* ignore */ }
+  }
+
+  return { installed, label, plistPath, loaded, lastRunAt, intervalSeconds };
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -15,6 +15,8 @@ export interface CortexConfig {
   bucketSize?: number;
   onboardingDepth?: number;
   engramTTLDays?: number;
+  idleWindowMinutes?: number;
+  staleWindowMinutes?: number;
 }
 
 export interface Config {


### PR DESCRIPTION
## Summary

Background curation without a daemon. A dumb periodic scheduler (macOS LaunchAgent, 5-min cadence) fires `think curate --if-idle`; the CLI itself decides whether each firing should do anything. Most firings are sub-10ms no-ops. Real curation runs at natural pauses in activity, or when a burst has been sitting too long.

## Design

Two parts, intentionally split:

- **When to fire** (scheduler's job) — a launchd plist on a fixed interval.
- **Whether to actually do anything** (CLI's job) — `--if-idle` asks three questions:
  1. Any pending engrams? *If no → exit.*
  2. Is the newest engram younger than `idleWindowMinutes` (default 3)? *If yes → user is still mid-burst, exit.*
  3. Is the oldest engram older than `staleWindowMinutes` (default 60)? *If yes → staleness cap wins, run anyway.*
  4. Otherwise → idle, curate.

Putting the intelligence in the CLI keeps the scheduler dumb and testable. Run `think curate --if-idle` manually and watch it decide. Any scheduler works (cron, systemd, launchd, Task Scheduler) — we ship a macOS plist; Linux users point their own at the same command.

Safe with the three-status engram model from #21: unpromoted engrams stay pending across firings until they mature or age out at TTL. No destructive re-evaluation.

## Multi-workspace support

Label is derived from a short hash of `THINK_HOME`, so personal and work workspaces get separate agents with separate plists. Installing in each workspace's shell creates two independent agents, each with its own `THINK_HOME` baked into the plist. No coordination, no cross-contamination.

## New surface

- `think curate --if-idle` — decision logic described above. Used by the scheduler; safe to run manually.
- `think cortex auto-curate enable [--interval <seconds>]` — writes a workspace-scoped plist, loads it via `launchctl`.
- `think cortex auto-curate disable` — unloads and removes.
- `think cortex auto-curate status` — shows label, install/load state, interval, plist path, last-log mtime.
- Config keys: `cortex.idleWindowMinutes` (default 3), `cortex.staleWindowMinutes` (default 60).

## Test plan

- [x] `--if-idle` with stale backlog (oldest 2583min old) correctly fired the staleness cap and started a real curate.
- [x] `auto-curate status` on uninstalled workspace shows correct hash-derived label and "no" install state.
- [x] Build clean, typecheck errors unchanged from main (14 pre-existing).
- [ ] `auto-curate enable` on live workspace → verify plist contents, `launchctl list` shows loaded, wait for a firing, check log file.
- [ ] Confirm second workspace with different `THINK_HOME` gets a different label and doesn't collide.
- [ ] `auto-curate disable` → verify plist removed and `launchctl list` no longer shows it.

## Platform notes

macOS-only for `enable`/`disable` today. Linux users can run `think curate --if-idle` from cron or a systemd timer and get identical behavior; docs addition for that deferred.