### PR TITLE
feat: lockfile prevents concurrent curation runs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "think",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "think",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.98",
         "chalk": "^5.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-think",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "type": "module",
   "description": "Local-first CLI that gives AI agents persistent, curated memory",
   "bin": {

--- a/src/commands/curate.ts
+++ b/src/commands/curate.ts
@@ -43,6 +43,7 @@ export const curateCommand = new Command('curate')
     // Concurrency lock: prevent two curation runs from writing to the same
     // cortex DB at once. Scheduler firings can overlap if curation takes
     // longer than the scheduler interval. Skip for --dry-run (read-only).
+    let releaseLock: () => void = () => {};
     if (!opts.dryRun) {
       const lock = acquireCurateLock(cortex);
       if (!lock.acquired) {
@@ -56,9 +57,10 @@ export const curateCommand = new Command('curate')
         closeCortexDb(cortex);
         return;
       }
-      // Lock released automatically on process exit via registered hooks.
+      releaseLock = lock.release;
     }
 
+    try {
     // --if-idle: bail early unless conditions are right. The scheduler fires
     // on a fixed cadence, so most firings should exit here in milliseconds.
     // Skip the check for explicit episode/consolidate runs — those are manual.
@@ -393,6 +395,9 @@ export const curateCommand = new Command('curate')
     }
 
     closeCortexDb(cortex);
+    } finally {
+      releaseLock();
+    }
   });
 
 const DEFAULT_IDLE_WINDOW_MINUTES = 3;

--- a/src/commands/curate.ts
+++ b/src/commands/curate.ts
@@ -17,6 +17,7 @@ import {
 } from '../lib/curator.js';
 import { getSyncAdapter } from '../sync/registry.js';
 import type { MemoryEntry } from '../lib/curator.js';
+import { acquireCurateLock } from '../lib/curate-lock.js';
 
 export const curateCommand = new Command('curate')
   .description('Run curation: evaluate pending engrams and promote to memories')
@@ -38,6 +39,25 @@ export const curateCommand = new Command('curate')
     }
 
     const author = config.cortex!.author;
+
+    // Concurrency lock: prevent two curation runs from writing to the same
+    // cortex DB at once. Scheduler firings can overlap if curation takes
+    // longer than the scheduler interval. Skip for --dry-run (read-only).
+    if (!opts.dryRun) {
+      const lock = acquireCurateLock(cortex);
+      if (!lock.acquired) {
+        if (opts.ifIdle) {
+          if (process.env.THINK_IDLE_DEBUG) {
+            console.log(chalk.dim(`[auto-curate] skipped: another curation is running (pid ${lock.heldByPid ?? '?'})`));
+          }
+        } else {
+          console.log(chalk.yellow(`Another curation is already running (pid ${lock.heldByPid ?? '?'}). Skipping.`));
+        }
+        closeCortexDb(cortex);
+        return;
+      }
+      // Lock released automatically on process exit via registered hooks.
+    }
 
     // --if-idle: bail early unless conditions are right. The scheduler fires
     // on a fixed cadence, so most firings should exit here in milliseconds.

--- a/src/lib/curate-lock.ts
+++ b/src/lib/curate-lock.ts
@@ -78,18 +78,40 @@ export function acquireCurateLock(cortex: string): LockResult {
 
 function makeAcquired(lockPath: string): LockAcquired {
   let released = false;
-  const release = () => {
+
+  // Core unlink — idempotent via the `released` flag so the exit/signal
+  // handlers can't race with an explicit release() call.
+  const unlinkIfHeld = () => {
     if (released) return;
     released = true;
     try { fs.unlinkSync(lockPath); } catch { /* already gone */ }
   };
 
-  // Best-effort release on abnormal exit. finally-blocks cover the normal
-  // path; these cover SIGTERM / SIGINT / uncaught exceptions.
-  const cleanup = () => release();
-  process.once('exit', cleanup);
-  process.once('SIGINT', () => { cleanup(); process.exit(130); });
-  process.once('SIGTERM', () => { cleanup(); process.exit(143); });
+  // Signal handlers: clean up *this* lock, then propagate the signal's
+  // usual exit code. Each lock owns its own handler instances so release()
+  // can remove them precisely — important for long-running processes that
+  // acquire/release multiple times (tests, future daemons).
+  const exitHandler = () => { unlinkIfHeld(); };
+  const sigintHandler = () => { unlinkIfHeld(); process.exit(130); };
+  const sigtermHandler = () => { unlinkIfHeld(); process.exit(143); };
+
+  process.on('exit', exitHandler);
+  process.on('SIGINT', sigintHandler);
+  process.on('SIGTERM', sigtermHandler);
+
+  const release = () => {
+    if (released) {
+      // Even on double-release, drop the handlers so they don't linger.
+      process.removeListener('exit', exitHandler);
+      process.removeListener('SIGINT', sigintHandler);
+      process.removeListener('SIGTERM', sigtermHandler);
+      return;
+    }
+    unlinkIfHeld();
+    process.removeListener('exit', exitHandler);
+    process.removeListener('SIGINT', sigintHandler);
+    process.removeListener('SIGTERM', sigtermHandler);
+  };
 
   return { acquired: true, release };
 }

--- a/src/lib/curate-lock.ts
+++ b/src/lib/curate-lock.ts
@@ -1,0 +1,95 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { getThinkDir } from './paths.js';
+
+function getLockPath(cortex: string): string {
+  return path.join(getThinkDir(), `curate-${cortex}.lock`);
+}
+
+function isProcessAlive(pid: number): boolean {
+  if (!Number.isFinite(pid) || pid <= 0) return false;
+  try {
+    // Signal 0 checks whether the process exists without actually signaling it.
+    // Throws ESRCH if the process doesn't exist, EPERM if it exists but we
+    // can't signal it — either way, EPERM means "alive enough for our check."
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    return code === 'EPERM';
+  }
+}
+
+export interface LockAcquired {
+  acquired: true;
+  release: () => void;
+}
+
+export interface LockRejected {
+  acquired: false;
+  heldByPid: number | null;
+}
+
+export type LockResult = LockAcquired | LockRejected;
+
+export function acquireCurateLock(cortex: string): LockResult {
+  const lockPath = getLockPath(cortex);
+  fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+
+  // First attempt: exclusive create.
+  try {
+    fs.writeFileSync(lockPath, String(process.pid), { flag: 'wx' });
+    return makeAcquired(lockPath);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
+  }
+
+  // Lock file exists — check if the holder is still alive.
+  let heldByPid: number | null = null;
+  try {
+    const raw = fs.readFileSync(lockPath, 'utf-8').trim();
+    const parsed = parseInt(raw, 10);
+    if (Number.isFinite(parsed) && parsed > 0) heldByPid = parsed;
+  } catch { /* unreadable lock — treat as stale */ }
+
+  if (heldByPid && isProcessAlive(heldByPid)) {
+    return { acquired: false, heldByPid };
+  }
+
+  // Stale lock — take it over.
+  try { fs.unlinkSync(lockPath); } catch { /* raced — fall through */ }
+  try {
+    fs.writeFileSync(lockPath, String(process.pid), { flag: 'wx' });
+    return makeAcquired(lockPath);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'EEXIST') {
+      // Someone else took it in the race. Re-read and report.
+      let nowHeldBy: number | null = null;
+      try {
+        const raw = fs.readFileSync(lockPath, 'utf-8').trim();
+        const parsed = parseInt(raw, 10);
+        if (Number.isFinite(parsed) && parsed > 0) nowHeldBy = parsed;
+      } catch { /* ignore */ }
+      return { acquired: false, heldByPid: nowHeldBy };
+    }
+    throw err;
+  }
+}
+
+function makeAcquired(lockPath: string): LockAcquired {
+  let released = false;
+  const release = () => {
+    if (released) return;
+    released = true;
+    try { fs.unlinkSync(lockPath); } catch { /* already gone */ }
+  };
+
+  // Best-effort release on abnormal exit. finally-blocks cover the normal
+  // path; these cover SIGTERM / SIGINT / uncaught exceptions.
+  const cleanup = () => release();
+  process.once('exit', cleanup);
+  process.once('SIGINT', () => { cleanup(); process.exit(130); });
+  process.once('SIGTERM', () => { cleanup(); process.exit(143); });
+
+  return { acquired: true, release };
+}


### PR DESCRIPTION
## Summary

Prevents two `think curate` processes from writing to the same cortex DB at once. If the scheduler fires while a previous curation is still running (possible when curation takes longer than the 5-min interval), the second process sees the lock and exits instead of racing with the first.

## Behavior

- **Lock acquired, run proceeds** → normal case. Lock released on process exit via hooks on `'exit'`, `SIGINT`, `SIGTERM`.
- **Lock held by live process, `--if-idle`** → silent skip. Scheduler will retry next fire.
- **Lock held by live process, manual run** → yellow message: "Another curation is already running (pid N). Skipping."
- **Lock held by dead process** (stale lock from a crashed run) → take over via `process.kill(pid, 0)` aliveness check.
- **`--dry-run`** → skips the lock (read-only).

Per-cortex lock path: `$THINK_HOME/curate-<cortex>.lock`. Personal and work workspaces don't collide because they have different `THINK_HOME`s.

## Test plan

- [x] Held-live lock + `--if-idle` → silent skip, correct PID reported in debug log.
- [x] Held-live lock + manual → yellow "already running" message.
- [x] Stale lock (dead PID) → lock taken over, new run proceeds.
- [x] Build + typecheck unchanged from main.
- [ ] Verify lock released on normal curate exit (observable via `ls $THINK_HOME/*.lock` after a run).
- [ ] Verify lock released on SIGINT (Ctrl-C during a curate).