### PR TITLE
fix: isolate long-term push/pull and verify update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "think",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "think",
-      "version": "0.3.4",
+      "version": "0.4.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.98",
         "chalk": "^5.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-think",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "type": "module",
   "description": "Local-first CLI that gives AI agents persistent, curated memory",
   "bin": {

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,28 +1,76 @@
+import fs from 'node:fs';
+import path from 'node:path';
 import { Command } from 'commander';
 import { execFileSync } from 'node:child_process';
 import chalk from 'chalk';
+
+function getInstalledVersion(): string | null {
+  try {
+    const npmRoot = execFileSync('npm', ['root', '-g'], { encoding: 'utf-8' }).trim();
+    const pkgPath = path.join(npmRoot, 'open-think', 'package.json');
+    if (!fs.existsSync(pkgPath)) return null;
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+    return typeof pkg.version === 'string' ? pkg.version : null;
+  } catch {
+    return null;
+  }
+}
+
+function getLatestPublishedVersion(): string | null {
+  try {
+    const v = execFileSync('npm', ['view', 'open-think', 'version'], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    return v || null;
+  } catch {
+    return null;
+  }
+}
 
 export const updateCommand = new Command('update')
   .description('Update think to the latest version')
   .action(() => {
     console.log(chalk.cyan('Checking for updates...'));
 
+    const before = getInstalledVersion();
+    const latest = getLatestPublishedVersion();
+
+    if (before && latest && before === latest) {
+      console.log(chalk.dim(`Already up to date (open-think@${before}).`));
+      return;
+    }
+
+    // `--prefer-online` forces npm to check the registry for fresh tag metadata
+    // instead of trusting a potentially stale local cache. Without it, npm can
+    // silently no-op on `@latest` when its cached latest tag is behind.
     try {
-      const result = execFileSync('npm', ['install', '-g', 'open-think@latest'], {
+      execFileSync('npm', ['install', '-g', '--prefer-online', 'open-think@latest'], {
         encoding: 'utf-8',
         stdio: ['pipe', 'pipe', 'pipe'],
       });
-
-      // Extract version from npm output
-      const match = result.match(/open-think@(\S+)/);
-      const version = match ? match[1] : 'latest';
-
-      console.log(chalk.green('✓') + ` Updated to open-think@${version}`);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       console.error(chalk.red('Update failed. Try manually: npm install -g open-think@latest'));
       if (message.includes('EACCES')) {
         console.error(chalk.dim('  You may need to run with sudo or fix npm permissions.'));
       }
+      return;
+    }
+
+    // Verify the install actually landed. npm can exit 0 while doing nothing
+    // if its cache thinks the current install satisfies `@latest`.
+    const after = getInstalledVersion();
+    if (after && latest && after === latest) {
+      console.log(chalk.green('✓') + ` Updated to open-think@${after}`);
+    } else if (after && before && after !== before) {
+      console.log(chalk.green('✓') + ` Updated to open-think@${after}${latest ? chalk.dim(` (registry says latest is ${latest})`) : ''}`);
+    } else if (after && latest && after !== latest) {
+      console.error(chalk.yellow('⚠') + ` npm reported success but installed version is ${after}, expected ${latest}.`);
+      console.error(chalk.dim('  Try: npm cache clean --force && npm install -g open-think@latest'));
+    } else if (after) {
+      console.log(chalk.dim(`Installed version: open-think@${after} (could not verify against registry).`));
+    } else {
+      console.error(chalk.yellow('⚠') + ' Could not locate the installed package to verify the update.');
     }
   });

--- a/src/sync/git-adapter.ts
+++ b/src/sync/git-adapter.ts
@@ -68,9 +68,23 @@ export class GitSyncAdapter implements SyncAdapter {
   async push(cortex: string): Promise<SyncResult> {
     const result: SyncResult = { pushed: 0, pulled: 0, errors: [] };
 
-    ensureRepoCloned();
-    fetchBranch(cortex);
+    try {
+      ensureRepoCloned();
+      fetchBranch(cortex);
+    } catch (err) {
+      result.errors.push(err instanceof Error ? err.message : String(err));
+      return result;
+    }
 
+    // Memory push and long-term event push are independent. Keep them as
+    // separate steps so one having nothing to send doesn't starve the other.
+    this.pushMemories(cortex, result);
+    this.pushLongTermEvents(cortex, result);
+
+    return result;
+  }
+
+  private pushMemories(cortex: string, result: SyncResult): void {
     // Get last push cursor (sync_version)
     const cursorStr = getSyncCursor(cortex, 'git', 'push');
     const lastVersion = cursorStr ? parseInt(cursorStr, 10) : 0;
@@ -81,7 +95,7 @@ export class GitSyncAdapter implements SyncAdapter {
       this.ensureMigrated(cortex, branchFiles);
     } catch (err) {
       result.errors.push(`Migration failed: ${err instanceof Error ? err.message : String(err)}`);
-      return result;
+      return;
     }
 
     // Re-read after potential migration (migration changes the file list)
@@ -91,7 +105,7 @@ export class GitSyncAdapter implements SyncAdapter {
 
     // Get memories created since last push
     const newMemories = getMemoriesBySyncVersion(cortex, lastVersion);
-    if (newMemories.length === 0) return result;
+    if (newMemories.length === 0) return;
 
     // Determine which bucket file to write to
     const targetFile = this.determineBucketFile(cortex, currentFiles);
@@ -125,15 +139,10 @@ export class GitSyncAdapter implements SyncAdapter {
     try {
       appendAndCommit(cortex, newLines, commitMsg, 3, targetFile);
       setSyncCursor(cortex, 'git', 'push', String(maxVersion));
-      result.pushed = newMemories.length;
+      result.pushed += newMemories.length;
     } catch (err) {
       result.errors.push(err instanceof Error ? err.message : String(err));
     }
-
-    // Long-term events push — same cursor-driven pattern, separate file.
-    this.pushLongTermEvents(cortex, result);
-
-    return result;
   }
 
   private pushLongTermEvents(cortex: string, result: SyncResult): void {
@@ -216,6 +225,15 @@ export class GitSyncAdapter implements SyncAdapter {
       return result;
     }
 
+    // Memory pull and long-term event pull are independent. Running both
+    // unconditionally ensures an empty memory side doesn't strand events.
+    this.pullMemories(cortex, result);
+    this.pullLongTermEvents(cortex, result);
+
+    return result;
+  }
+
+  private pullMemories(cortex: string, result: SyncResult): void {
     const config = getConfig();
     const onboardingDepth = config.cortex?.onboardingDepth ?? 1500;
     const bucketSize = config.cortex?.bucketSize ?? 500;
@@ -231,7 +249,7 @@ export class GitSyncAdapter implements SyncAdapter {
       if (memoriesRaw) {
         this.processMemories(cortex, memoriesRaw, result);
       }
-      return result;
+      return;
     }
 
     // Determine which files to read
@@ -274,11 +292,6 @@ export class GitSyncAdapter implements SyncAdapter {
     if (lastReadFile) {
       setSyncCursor(cortex, 'git', 'pull_file', lastReadFile);
     }
-
-    // Pull long-term events — single file, not bucketed.
-    this.pullLongTermEvents(cortex, result);
-
-    return result;
   }
 
   private pullLongTermEvents(cortex: string, result: SyncResult): void {


### PR DESCRIPTION
## Summary

Two unrelated fixes, both caught in production today.

### 1. Long-term events get stranded when there are no new memories to push

\`push()\` and \`pull()\` each short-circuited on the memory side before the long-term branch ran. So:

- **Backfill** (33 events, 0 memories) → push exited at the \`newMemories.length === 0\` early return, \`pushLongTermEvents\` never ran, events stayed local forever.
- **Curation runs** that happen to emit a long-term event without producing any new memory (e.g., the curator synthesizes an event from memories already visible in the prompt) had the same problem.
- **Manual \`cortex push\`** after backfill was a no-op for the same reason.

Pull had the same shape in the no-bucket-files edge case.

Fix: split \`push\` and \`pull\` into independent per-tier helpers. The top-level method runs both unconditionally; each helper handles its own early-return. Memory-push's \`result.pushed\` assignment switched to \`+=\` so the top-level counter now reflects both tiers.

Verified locally: 33 events sitting unshipped after backfill → single \`cortex push\` after the fix pushed all 33 to \`long-term.jsonl\` on the remote (file size 35245 bytes, 33 lines).

### 2. \`think update\` reports success on a silent no-op

\`npm install -g open-think@latest\` will silently no-op when npm's cached \`latest\` tag metadata is stale — exits 0, doesn't upgrade, \`think update\` prints a green checkmark. Repro'd today: npm registry had 0.4.0 published, \`think update\` said ✓, installed version stayed at 0.3.5.

Update now:
1. Reads the installed version from \`\$(npm root -g)/open-think/package.json\` before.
2. Fetches \`npm view open-think version\`.
3. Short-circuits if already at latest.
4. Runs install with \`--prefer-online\` so npm hits the registry instead of trusting the cache.
5. Re-reads the installed version after install and prints honest output: up-to-date, upgraded to X, or **warning** that npm reported success but the version didn't move.

## Test plan

- [x] Build clean, typecheck unchanged (14 pre-existing).
- [x] \`cortex push\` against real state — pushed the 33 stranded events.
- [x] Verified \`long-term.jsonl\` on MMS-think-DB/personal has the 33 events.
- [ ] \`think update\` on a machine already at latest → "Already up to date" message.
- [ ] \`think update\` on a machine behind → correct upgrade path, accurate before/after reporting.
- [ ] \`think update\` in a simulated cache-stale scenario → warning surfaces rather than false success.