### PR TITLE
fix: surface sync push/pull errors and normalize repo URL check

### DIFF
--- a/src/commands/curate.ts
+++ b/src/commands/curate.ts
@@ -17,6 +17,7 @@ import {
   runConsolidation,
 } from '../lib/curator.js';
 import { getSyncAdapter } from '../sync/registry.js';
+import { formatSyncError } from '../sync/errors.js';
 import type { MemoryEntry } from '../lib/curator.js';
 import { acquireCurateLock } from '../lib/curate-lock.js';
 
@@ -87,8 +88,11 @@ export const curateCommand = new Command('curate')
         if (pullResult.pulled > 0) {
           console.log(chalk.dim(`  Pulled ${pullResult.pulled} memories from ${adapter.name}`));
         }
-      } catch {
-        console.log(chalk.dim('  Sync pull skipped (remote unavailable)'));
+        for (const msg of pullResult.errors) {
+          console.log(chalk.yellow(`  ⚠ Pull: ${formatSyncError(msg)}`));
+        }
+      } catch (err) {
+        console.log(chalk.yellow(`  ⚠ Pull failed: ${formatSyncError(err)}`));
       }
     }
 
@@ -171,8 +175,11 @@ export const curateCommand = new Command('curate')
           if (pushResult.pushed > 0) {
             console.log(chalk.dim(`  Pushed ${pushResult.pushed} memories to ${adapter.name}`));
           }
-        } catch {
-          console.log(chalk.dim('  Sync push skipped (remote unavailable)'));
+          for (const msg of pushResult.errors) {
+            console.log(chalk.yellow(`  ⚠ Push: ${formatSyncError(msg)}`));
+          }
+        } catch (err) {
+          console.log(chalk.yellow(`  ⚠ Push failed: ${formatSyncError(err)}`));
         }
       }
 
@@ -417,8 +424,11 @@ export const curateCommand = new Command('curate')
         if (pushResult.pushed > 0) {
           console.log(chalk.dim(`  Pushed ${pushResult.pushed} items to ${adapter.name}`));
         }
-      } catch {
-        console.log(chalk.dim('  Sync push skipped (remote unavailable) — will push on next sync'));
+        for (const msg of pushResult.errors) {
+          console.log(chalk.yellow(`  ⚠ Push: ${formatSyncError(msg)}`));
+        }
+      } catch (err) {
+        console.log(chalk.yellow(`  ⚠ Push failed: ${formatSyncError(err)}`));
       }
     }
 

--- a/src/commands/long-term.ts
+++ b/src/commands/long-term.ts
@@ -13,6 +13,7 @@ import { closeCortexDb } from '../db/engrams.js';
 import { wrapData } from '../lib/sanitize.js';
 import type { LongTermEventProposal } from '../lib/curator.js';
 import { getSyncAdapter } from '../sync/registry.js';
+import { formatSyncError } from '../sync/errors.js';
 
 const BACKFILL_SYSTEM_PROMPT = `You are a long-term memory curator performing a one-time backfill. You receive a batch of historical memories from a single month and produce the durable long-term events that summarize what happened.
 
@@ -332,8 +333,11 @@ longTermCommand.addCommand(new Command('backfill')
         if (pushResult.pushed > 0) {
           console.log(chalk.dim(`  Pushed ${pushResult.pushed} items to ${adapter.name}`));
         }
-      } catch {
-        console.log(chalk.dim('  Sync push skipped (remote unavailable) — will push on next sync'));
+        for (const msg of pushResult.errors) {
+          console.log(chalk.yellow(`  ⚠ Push: ${formatSyncError(msg)}`));
+        }
+      } catch (err) {
+        console.log(chalk.yellow(`  ⚠ Push failed: ${formatSyncError(err)}`));
       }
     }
 

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -5,6 +5,7 @@ import { getMemories, insertMemory } from '../db/memory-queries.js';
 import { printDecisions } from './recall.js';
 import { closeCortexDb } from '../db/engrams.js';
 import { getSyncAdapter } from '../sync/registry.js';
+import { formatSyncError } from '../sync/errors.js';
 import { validateEngramContent } from '../lib/sanitize.js';
 
 const addCommand = new Command('add')
@@ -58,9 +59,14 @@ const addCommand = new Command('add')
           if (!opts.silent && result.pushed > 0) {
             console.log(chalk.dim(`  Pushed ${result.pushed} memories to ${adapter.name}`));
           }
-        } catch {
           if (!opts.silent) {
-            console.log(chalk.dim('  Push skipped (remote unavailable) — will push on next sync'));
+            for (const msg of result.errors) {
+              console.log(chalk.yellow(`  ⚠ Push: ${formatSyncError(msg)}`));
+            }
+          }
+        } catch (err) {
+          if (!opts.silent) {
+            console.log(chalk.yellow(`  ⚠ Push failed: ${formatSyncError(err)}`));
           }
         }
       }

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { getRepoPath } from './paths.js';
 import { getConfig } from './config.js';
-import { validateRepoUrl } from './repo-url.js';
+import { validateRepoUrl, repoUrlsEquivalent } from './repo-url.js';
 
 // Sanitized environment for git subprocesses — strips variables that could
 // alter git behavior (hook injection, credential interception, path redirection)
@@ -101,7 +101,11 @@ export function ensureRepoCloned(): void {
 
   if (fs.existsSync(path.join(repoPath, '.git'))) {
     const remote = runGit(['remote', 'get-url', 'origin'], repoPath);
-    if (remote !== config.cortex.repo) {
+    // Compare by normalized (host, path) so ssh://, https://, and the SCP
+    // shortcut for the same repo don't trigger a false mismatch — the common
+    // case is a user flipping the on-disk remote's transport without touching
+    // config (or vice versa). If they actually point elsewhere, still throw.
+    if (!repoUrlsEquivalent(remote, config.cortex.repo)) {
       throw new Error(`Repo at ${repoPath} points to ${remote}, expected ${config.cortex.repo}`);
     }
     return;

--- a/src/lib/repo-url.ts
+++ b/src/lib/repo-url.ts
@@ -28,3 +28,37 @@ export function validateRepoUrl(url: string): void {
     );
   }
 }
+
+// Parse any accepted repo URL into (host, path) so callers can decide two URLs
+// point at the same repo despite transport differences. Returns null when the
+// input doesn't match a known shape — callers fall back to strict comparison.
+function parseRepoUrl(url: string): { host: string; path: string } | null {
+  if (!url) return null;
+  let host: string;
+  let path: string;
+
+  const scp = url.match(/^[\w.-]+@([^:\s]+):(.+)$/);
+  if (scp) {
+    host = scp[1];
+    path = scp[2];
+  } else {
+    const withScheme = url.match(/^(?:https?|ssh|git):\/\/(?:[^@/]+@)?([^/\s]+)\/(.+)$/i);
+    if (!withScheme) return null;
+    host = withScheme[1];
+    path = withScheme[2];
+  }
+
+  path = path.replace(/\/+$/, '').replace(/\.git$/i, '').replace(/\/+$/, '');
+  return { host: host.toLowerCase(), path };
+}
+
+// Two remote URLs are equivalent when they resolve to the same host and path,
+// ignoring transport (ssh vs https), `.git` suffix, trailing slashes, and
+// userinfo. Falls back to strict equality if either URL can't be parsed.
+export function repoUrlsEquivalent(a: string, b: string): boolean {
+  if (a === b) return true;
+  const pa = parseRepoUrl(a);
+  const pb = parseRepoUrl(b);
+  if (!pa || !pb) return false;
+  return pa.host === pb.host && pa.path === pb.path;
+}

--- a/src/sync/errors.ts
+++ b/src/sync/errors.ts
@@ -1,0 +1,11 @@
+// Format any thrown or collected sync error as a single readable line.
+// Sync callers (curate, memory add, cortex push) used to swallow these and
+// print a generic "remote unavailable" message, which hid real failures like
+// SSH auth errors — see hivedb#4. Showing the first line of the actual error
+// preserves the signal without dumping multi-line stack traces on the user.
+export function formatSyncError(err: unknown): string {
+  const raw = err instanceof Error ? err.message : String(err);
+  const firstLine = raw.split('\n').map(s => s.trim()).find(Boolean) ?? raw;
+  const MAX = 200;
+  return firstLine.length > MAX ? firstLine.slice(0, MAX - 1) + '…' : firstLine;
+}


### PR DESCRIPTION
## Summary
- Curate / memory add / long-term backfill now print the actual first line of sync push/pull errors (in yellow) instead of the generic "remote unavailable" message that hid real failures like SSH auth errors.
- `ensureRepoCloned` now compares the on-disk remote against `config.cortex.repo` by normalized `(host, path)`, so the SCP shortcut, `https://`, and `ssh://` forms of the same repo don't trip a false mismatch.

## Why
Per [hivedb#4](https://github.com/Anglepoint-Inc/hivedb/issues/4): a teammate saw `✓ Curation complete` while pushes silently failed because his SSH key wasn't set up. The real `Permission denied (publickey)` error was caught and flattened to "remote unavailable". He also ran into the strict URL equality check after flipping `git remote set-url` to try HTTPS — config said `git@…` but working tree said `https://…`, so `ensureRepoCloned` threw an error that was itself swallowed by the same catch.

## Changes
- `src/sync/errors.ts` (new): `formatSyncError()` — trims to first line, caps at 200 chars.
- `src/lib/repo-url.ts`: `repoUrlsEquivalent()` — parses SSH / SCP shortcut / HTTPS / ssh:// / git:// into `(host, path)`, strips `.git` + trailing slashes, case-insensitive host. Falls back to strict equality when either URL is unparseable.
- `src/lib/git.ts`: `ensureRepoCloned` uses `repoUrlsEquivalent` instead of `!==`.
- `src/commands/curate.ts` (3 sites), `src/commands/memory.ts`, `src/commands/long-term.ts`: print the real error, and also surface `result.errors[]` when the call returns successfully but contains errors (e.g., migration failure, appendAndCommit failure).

## Test plan
- [x] `npm run build` — clean
- [x] `repoUrlsEquivalent` smoke-tested against 8 cases (SSH↔HTTPS, `.git`, trailing slash, userinfo, self-hosted, mismatched host, mismatched path) — all pass
- [ ] Manual: trigger a real push failure (revoke SSH key temporarily) and confirm the error line reaches the terminal instead of being swallowed
- [ ] Manual: `git -C ~/.think/repo remote set-url origin https://…` while config has SSH form — subsequent `think cortex push` no longer throws mismatch

## Notes
- Do not merge via GitHub's merge button — this repo is gated by stamp-cli (see STAMP.md). Merge locally via `stamp merge fix/surface-sync-push-errors --into main`.
- Swallowing catches at `long-term.ts:436` (`/* best effort */`) intentionally left alone — that site is a background cleanup that shouldn't surface noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)