### PR TITLE
fix(build): add `-S` to env shebang so Linux containers can execute the CLI

### DIFF
--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -13,7 +13,17 @@ export default defineConfig({
   // siblings intact. Same reason `@anthropic-ai/claude-agent-sdk` is external.
   external: ['@anthropic-ai/claude-agent-sdk', '@huggingface/transformers'],
   banner: {
-    js: '#!/usr/bin/env node --no-warnings=ExperimentalWarning',
+    // `env -S` is required so the kernel passes `node` and
+    // `--no-warnings=ExperimentalWarning` as separate args to env (which
+    // then splits them on its own). Without `-S`, the kernel hands env a
+    // single literal arg "node --no-warnings=ExperimentalWarning"; GNU env
+    // (Debian 12 / coreutils 9.1, used on every common Linux container
+    // base) can't find a binary by that exact name and falls back to
+    // exec'ing the next arg — which is the script itself — re-triggering
+    // the shebang dispatch and producing an infinite re-exec loop. macOS
+    // BSD env silently tolerates the missing `-S`, which is why the bug
+    // hides on dev laptops.
+    js: '#!/usr/bin/env -S node --no-warnings=ExperimentalWarning',
   },
   // tsup defaults `removeNodeProtocol` to true, which strips the `node:`
   // prefix from every builtin import. That's harmless for `node:path` (the


### PR DESCRIPTION
## Summary

One-character fix to `packages/cli/tsup.config.ts` — adds `-S` to the env shebang banner so it works on Linux. **Critical: without this, open-think's published binary cannot be run via its shebang on any Debian/Ubuntu/Alpine-based container.**

## The bug

The bundled CLI shebang was:
```
#!/usr/bin/env node --no-warnings=ExperimentalWarning
```

Without `-S`, the Linux kernel passes everything after `env` as a single literal arg (`"node --no-warnings=ExperimentalWarning"`, with the space). GNU coreutils env (Debian 12 / 9.1, used on every common Linux container base) can't find a binary by that name. Instead of erroring out cleanly, it falls back to exec'ing the next arg — which is the script itself — re-triggering the shebang dispatch.

**Result: infinite re-exec loop.** Container shows Online, `think serve` / `think --version` / `think --help` all hang at CPU pegged with no stdout. PIDs accumulate in `/proc` from the runaway exec.

macOS BSD env silently tolerates the missing `-S`, which is why this never surfaced in dev. The bug only appears on Linux container deployments — exactly where it does maximum damage.

## How discovered

End-to-end deploy of `open-think@0.4.1` to an Anglepoint Railway service (HiveDB proxy). Container booted, deploy key got mounted, but `think serve` never produced any log output despite Railway reporting Online. SSH'd in, found `think serve` (PID 6) in State R with no syscalls landing; `strace -p <pid> -f -e execve` showed the recursive `execve("/usr/local/bin/think", ["...", "--version"])` loop. Reproduced 1-for-1 in `node:22-bookworm-slim` Docker locally.

## The fix

```diff
   banner: {
-    js: '#!/usr/bin/env node --no-warnings=ExperimentalWarning',
+    js: '#!/usr/bin/env -S node --no-warnings=ExperimentalWarning',
   },
```

With a comment block explaining the macOS-vs-Linux divergence so this gotcha doesn't bite again.

## Verification

- ✅ `bun run build` — dist regenerates with new shebang
- ✅ Fresh `node:22-bookworm-slim` container: install `open-think@0.4.1`, swap in the rebuilt `dist/`, `think --version` returns instantly via shebang (vs. infinite loop before)
- ✅ `bun run test` — full suite passes in isolation. Three pre-existing failures on `main` (daemon socket tests on macOS, MCP subprocess test under parallel load) reproduce identically on this branch — unrelated.

## Compatibility

`env -S` has been in GNU coreutils since 8.30 (Aug 2018) and BusyBox since 1.30.0 (Dec 2018). Any base image newer than Debian 10 / Alpine 3.10 supports it. Modern macOS BSD env handles it too. No floor regression.

## Stamp gate

All three reviewers approved against base `891a9cf`:
- security: approved
- standards: approved
- product: approved

(Full reviewer prose available locally via `stamp log --reviews`.)