### PR TITLE
feat(paths): nest cortex files under <branch>/ subdir + migrate-layout

### DIFF
--- a/packages/cli/src/commands/cortex-migrate-layout.ts
+++ b/packages/cli/src/commands/cortex-migrate-layout.ts
@@ -1,0 +1,458 @@
+/**
+ * `think cortex migrate-layout` — one-shot migration that moves every cortex
+ * file under the canonical `<branchName>/` subdir on its branch.
+ *
+ * Why this exists
+ * ----------------
+ * Two write paths historically disagreed on where a cortex's files live in
+ * the git working tree:
+ *
+ *   1. The legacy `git-adapter` flow (`appendAndCommit` / `createOrphanBranch`)
+ *      wrote flat at the branch root: `<repo>/000001.jsonl`,
+ *      `<repo>/long-term.jsonl`, `<repo>/<peer>-retros.jsonl`.
+ *
+ *   2. The newer daemon + proxy flow (`sync-handler`, `compaction/apply`,
+ *      `supersession/apply`, `serve/cortex-writer`) wrote nested under a
+ *      per-cortex subdir: `<repo>/<branchName>/<file>`.
+ *
+ * Branches written by both paths ended up with a mixed layout — the
+ * `cortex/engineering` branch we used as the motivating example had four
+ * flat pages at root *and* a `cortex/engineering/000001.jsonl` inside the
+ * canonical subdir. Pull and reindex paths that used a non-recursive
+ * `ls-tree` silently missed the nested files; `reindex --force` could drop
+ * indexed entries that had no recoverable JSONL source.
+ *
+ * Canonical layout going forward
+ * ------------------------------
+ *   <repo>/<branchName>/000001.jsonl
+ *   <repo>/<branchName>/000002.jsonl
+ *   ...
+ *   <repo>/<branchName>/long-term.jsonl
+ *   <repo>/<branchName>/<peer>-retros.jsonl
+ *
+ * Migration rules
+ * ---------------
+ *  - Flat numbered pages at the branch root keep their numbers, in original
+ *    order. They are the older history.
+ *  - Existing nested numbered pages (in the canonical subdir *or* in any
+ *    non-canonical sibling subdir like `hivedb/` on the `cortex/hivedb`
+ *    branch) are renumbered to start at `max(flat) + 1`, preserving their
+ *    relative order. They are the newer history.
+ *  - Non-numbered cortex files (`long-term.jsonl`, `<peer>-retros.jsonl`,
+ *    legacy `memories.jsonl`) are moved into the canonical subdir under
+ *    their original basename; a collision with an existing nested file
+ *    aborts the migration for that branch.
+ *  - Idempotent: a branch that already has everything under the canonical
+ *    subdir produces no commit.
+ */
+
+import { Command } from 'commander';
+import chalk from 'chalk';
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import {
+  ensureRepoCloned,
+  fetchBranch,
+  listLocalBranches,
+  listBranchRootFiles,
+  safeGitEnv,
+} from '../lib/git.js';
+import { getRepoPath } from '../lib/paths.js';
+
+interface MigratePlan {
+  /** Existing flat numbered pages at the branch root, sorted. */
+  flatPages: string[];
+  /** `long-term.jsonl` at root, if present. */
+  flatLongTerm: string | null;
+  /** Top-level legacy `memories.jsonl`, if present (pre-v2). */
+  flatMemories: string | null;
+  /** `<peer>-retros.jsonl` at root, sorted. */
+  flatRetros: string[];
+  /**
+   * Nested files to relocate. Source is git-relative POSIX path; target is
+   * the new basename under the canonical `<branch>/` subdir.
+   */
+  moves: { source: string; targetBasename: string }[];
+  /**
+   * Renumbered nested pages already living under `<branch>/`: source is the
+   * existing nested path, targetBasename is the new `<NNNNNN>.jsonl` basename
+   * after renumbering past the flat pages.
+   */
+  canonicalRenumbers: { source: string; targetBasename: string }[];
+}
+
+/**
+ * Walk a directory recursively and collect every `.jsonl` file path
+ * relative to `repoRoot`, using forward slashes (POSIX paths for git).
+ */
+function collectJsonlPaths(repoRoot: string, dir: string, out: string[]): void {
+  let entries: string[];
+  try { entries = fs.readdirSync(dir); } catch { return; }
+  for (const entry of entries) {
+    const full = path.join(dir, entry);
+    let stat: fs.Stats;
+    try { stat = fs.statSync(full); } catch { continue; }
+    if (stat.isDirectory()) {
+      if (entry === '.git') continue;
+      collectJsonlPaths(repoRoot, full, out);
+    } else if (entry.endsWith('.jsonl')) {
+      const rel = path.relative(repoRoot, full).split(path.sep).join('/');
+      out.push(rel);
+    }
+  }
+}
+
+/**
+ * Run a single git command in the repo working tree, returning stdout. Uses
+ * the same hooks-disabled / sanitized-env setup as `lib/git.ts`.
+ */
+function git(args: string[], cwd: string): string {
+  const safeArgs = [
+    '-c', 'core.hooksPath=/dev/null',
+    '-c', 'core.fsmonitor=',
+    ...args,
+  ];
+  return execFileSync('git', safeArgs, {
+    cwd,
+    encoding: 'utf-8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: safeGitEnv(),
+  }).trim();
+}
+
+/**
+ * Construct the migration plan for a branch. Pure (filesystem reads only;
+ * no mutations). Returns null when nothing needs to move.
+ */
+function planBranchMigration(branch: string, repoPath: string): MigratePlan | null {
+  const rootEntries = listBranchRootFiles(branch);
+
+  const flatPages = rootEntries
+    .filter(f => /^\d{6}\.jsonl$/.test(f))
+    .sort();
+  const flatLongTerm = rootEntries.find(f => f === 'long-term.jsonl') ?? null;
+  const flatMemories = rootEntries.find(f => f === 'memories.jsonl') ?? null;
+  const flatRetros = rootEntries
+    .filter(f => f.endsWith('-retros.jsonl'))
+    .sort();
+
+  // Collect every nested .jsonl on the working tree. Path is git-relative
+  // using POSIX separators. Skip files already at their canonical location
+  // (they don't need to move) but still consider canonical numbered pages
+  // for renumbering past the flat history.
+  const canonicalPrefix = branch + '/';
+  const allNested: string[] = [];
+  collectJsonlPaths(repoPath, repoPath, allNested);
+  const nested = allNested.filter(p => p.includes('/')); // exclude root-level
+
+  const canonicalNested = nested
+    .filter(p => p.startsWith(canonicalPrefix))
+    .sort();
+  const offCanonicalNested = nested
+    .filter(p => !p.startsWith(canonicalPrefix))
+    .sort();
+
+  // Canonical numbered pages get renumbered to come after the flat pages.
+  // Determine the starting number: highest flat number + 1, or 1 if no flat
+  // numbered pages exist.
+  const flatMaxNum = flatPages.length > 0
+    ? parseInt(flatPages[flatPages.length - 1].replace('.jsonl', ''), 10)
+    : 0;
+  let nextNum = flatMaxNum + 1;
+
+  const canonicalRenumbers: MigratePlan['canonicalRenumbers'] = [];
+  const moves: MigratePlan['moves'] = [];
+
+  // First, handle canonical-nested numbered pages: renumber them.
+  // Non-numbered canonical files (long-term, retros, memories) are already in
+  // their final location and don't need to move.
+  const canonicalNumberedPages = canonicalNested
+    .filter(p => /^\d{6}\.jsonl$/.test(path.basename(p)))
+    .sort();
+  for (const src of canonicalNumberedPages) {
+    const target = String(nextNum).padStart(6, '0') + '.jsonl';
+    if (path.basename(src) !== target) {
+      canonicalRenumbers.push({ source: src, targetBasename: target });
+    }
+    nextNum++;
+  }
+
+  // Non-canonical nested .jsonl files (e.g. `hivedb/000001.jsonl` on the
+  // `cortex/hivedb` branch). Numbered pages get renumbered to continue the
+  // sequence; non-numbered files keep their basename and move into canonical.
+  // Sort numbered first to keep them in chronological order, then everything
+  // else, so the renumbering is deterministic.
+  const offCanonicalNumbered = offCanonicalNested
+    .filter(p => /^\d{6}\.jsonl$/.test(path.basename(p)))
+    .sort();
+  const offCanonicalOther = offCanonicalNested
+    .filter(p => !/^\d{6}\.jsonl$/.test(path.basename(p)))
+    .sort();
+  for (const src of offCanonicalNumbered) {
+    moves.push({ source: src, targetBasename: String(nextNum).padStart(6, '0') + '.jsonl' });
+    nextNum++;
+  }
+  for (const src of offCanonicalOther) {
+    moves.push({ source: src, targetBasename: path.basename(src) });
+  }
+
+  // Flat numbered pages move into canonical, preserving their numbers.
+  for (const f of flatPages) {
+    moves.push({ source: f, targetBasename: f });
+  }
+  if (flatLongTerm) {
+    moves.push({ source: flatLongTerm, targetBasename: 'long-term.jsonl' });
+  }
+  if (flatMemories) {
+    // `memories.jsonl` only ever existed pre-v2 as a single top-level file.
+    // If there's already a `<branch>/000001.jsonl` after renumbering, append
+    // memories as the next page rather than colliding.
+    const memTarget = flatPages.length === 0 && canonicalNumberedPages.length === 0
+      ? '000001.jsonl'
+      : String(nextNum).padStart(6, '0') + '.jsonl';
+    moves.push({ source: flatMemories, targetBasename: memTarget });
+    nextNum++;
+  }
+  for (const f of flatRetros) {
+    moves.push({ source: f, targetBasename: f });
+  }
+
+  if (moves.length === 0 && canonicalRenumbers.length === 0) {
+    return null;
+  }
+
+  return { flatPages, flatLongTerm, flatMemories, flatRetros, moves, canonicalRenumbers };
+}
+
+/**
+ * Execute a planned migration on the currently-checked-out branch. Renames
+ * via `git mv` go through git's index so the resulting commit shows them as
+ * renames. The canonical subdir is mkdir'd up front; existing collisions
+ * abort the migration.
+ */
+function applyPlan(plan: MigratePlan, branch: string, repoPath: string): void {
+  const canonicalDir = path.join(repoPath, branch);
+  fs.mkdirSync(canonicalDir, { recursive: true, mode: 0o700 });
+
+  // Pre-flight: refuse to overwrite any existing file at a target location.
+  const targets = new Set<string>();
+  const addTarget = (rel: string): void => {
+    if (targets.has(rel)) {
+      throw new Error(`Internal: duplicate migration target ${rel}`);
+    }
+    targets.add(rel);
+  };
+  for (const r of plan.canonicalRenumbers) {
+    addTarget(`${branch}/${r.targetBasename}`);
+  }
+  for (const m of plan.moves) {
+    addTarget(`${branch}/${m.targetBasename}`);
+  }
+
+  // Renumber canonical pages first (highest → lowest) to avoid intermediate
+  // name collisions. Build the rename order by sorting by source basename
+  // descending.
+  const canonicalSorted = [...plan.canonicalRenumbers].sort((a, b) =>
+    b.source.localeCompare(a.source),
+  );
+  for (const { source, targetBasename } of canonicalSorted) {
+    const target = `${branch}/${targetBasename}`;
+    // Two-step rename through a staging name avoids the edge case where the
+    // target equals another source in this same batch — e.g. renaming 000001
+    // → 000005 and 000005 → 000009 in one pass. The staging name uses a
+    // tilde suffix so it never collides with a real cortex file.
+    const stage = `${source}.migrating.tmp`;
+    git(['mv', '--', source, stage], repoPath);
+    git(['mv', '--', stage, target], repoPath);
+  }
+
+  for (const { source, targetBasename } of plan.moves) {
+    const target = `${branch}/${targetBasename}`;
+    if (fs.existsSync(path.join(repoPath, target))) {
+      throw new Error(`Cannot move ${source} → ${target}: target already exists.`);
+    }
+    git(['mv', '--', source, target], repoPath);
+  }
+
+  // Remove any now-empty non-canonical subdirs left behind by the moves.
+  // `git mv` doesn't delete the source dir; this keeps the post-migration
+  // tree clean without forcing an extra commit.
+  const rootEntries = fs.readdirSync(repoPath);
+  for (const entry of rootEntries) {
+    if (entry === '.git') continue;
+    const full = path.join(repoPath, entry);
+    if (!fs.statSync(full).isDirectory()) continue;
+    // Don't remove anything inside the canonical path.
+    if (entry === branch.split('/')[0]) continue;
+    // Recurse to check if the subtree is empty; if so, rm.
+    try {
+      fs.rmdirSync(full, { recursive: false });
+    } catch {
+      // Non-empty (or some other error) — leave it alone.
+    }
+  }
+}
+
+/**
+ * Migrate one branch. Switches to the branch, plans, applies, commits, and
+ * optionally pushes. Returns a short status string for the per-branch report.
+ */
+async function migrateOneBranch(
+  branch: string,
+  opts: { dryRun: boolean; push: boolean },
+): Promise<string> {
+  const repoPath = getRepoPath();
+
+  // Switch/fetch like `appendAndCommit` does — the migration must operate on
+  // the latest remote state, otherwise a peer who pushed between fetch and
+  // migrate would lose their writes during the rebase.
+  fetchBranch(branch);
+  try { git(['switch', '--', branch], repoPath); }
+  catch { git(['switch', '-c', branch, '--', `origin/${branch}`], repoPath); }
+  try { git(['pull', '--rebase', 'origin', '--', branch], repoPath); }
+  catch { /* first push / unborn upstream — proceed without rebase */ }
+
+  const plan = planBranchMigration(branch, repoPath);
+  if (!plan) return chalk.dim('already nested');
+
+  const fileCount = plan.moves.length + plan.canonicalRenumbers.length;
+
+  if (opts.dryRun) {
+    // Print the plan and return without changing anything.
+    process.stdout.write(`\n  ${chalk.cyan(branch)} (dry run):\n`);
+    for (const r of plan.canonicalRenumbers) {
+      process.stdout.write(`    rename  ${r.source} → ${branch}/${r.targetBasename}\n`);
+    }
+    for (const m of plan.moves) {
+      process.stdout.write(`    move    ${m.source} → ${branch}/${m.targetBasename}\n`);
+    }
+    return `${fileCount} file(s) ${chalk.dim('(dry run)')}`;
+  }
+
+  applyPlan(plan, branch, repoPath);
+
+  // `git mv` already staged each rename; one commit captures the whole tree.
+  const commitMsg = `migrate: nest cortex files under ${branch}/`;
+  try {
+    git(['commit', '-m', commitMsg], repoPath);
+  } catch (err) {
+    // Possible no-op (e.g. plan was non-empty but mv produced no net change);
+    // surface anything else.
+    const msg = err instanceof Error ? err.message : String(err);
+    if (!/nothing to commit/i.test(msg)) {
+      throw new Error(`commit failed on ${branch}: ${msg}`);
+    }
+    return chalk.dim('nothing to commit');
+  }
+
+  if (opts.push) {
+    git(['push', 'origin', '--', branch], repoPath);
+    return `${fileCount} file(s) committed, pushed`;
+  }
+  return `${fileCount} file(s) committed (push skipped)`;
+}
+
+export const cortexMigrateLayoutCommand = new Command('migrate-layout')
+  .description('One-time: nest cortex files under the <branch>/ subdir for every branch (or one named branch)')
+  .argument('[cortex]', 'Specific branch/cortex to migrate (defaults to every local branch)')
+  .option('--dry-run', 'Print the plan without committing or pushing', false)
+  .option('--no-push', 'Commit locally but skip git push')
+  .action(async (cortexArg: string | undefined, opts: { dryRun: boolean; push: boolean }) => {
+    try {
+      ensureRepoCloned();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(chalk.red(`No repo configured: ${msg}`));
+      process.exit(1);
+    }
+
+    let branches: string[];
+    if (cortexArg) {
+      branches = [cortexArg];
+    } else {
+      try {
+        branches = listLocalBranches();
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(chalk.red(`Could not enumerate local branches: ${msg}`));
+        process.exit(1);
+      }
+      if (branches.length === 0) {
+        console.error(chalk.yellow('No local branches found. Pass a cortex name explicitly:'));
+        console.error(chalk.dim('  think cortex migrate-layout <cortex-name>'));
+        process.exit(1);
+      }
+    }
+
+    console.log(chalk.cyan(`Migrating ${branches.length} branch(es) into nested layout...`));
+    if (opts.dryRun) {
+      console.log(chalk.dim('  (dry run — no commits or pushes)'));
+    }
+
+    // Capture the originally-checked-out branch so we can restore it at the
+    // end. Migrating leaves the working tree on whichever branch we processed
+    // last, and the daemon writes to the *currently-checked-out* working tree
+    // (no internal `git switch` per cortex). If the migration handed control
+    // back on the wrong branch, subsequent daemon writes would land on that
+    // branch's tree instead of the cortex's — surfaces as "ghost commits on
+    // main" after running this command.
+    const repoPath = getRepoPath();
+    let originalBranch: string | null = null;
+    try {
+      originalBranch = execFileSync('git', [
+        '-c', 'core.hooksPath=/dev/null',
+        '-c', 'core.fsmonitor=',
+        'rev-parse', '--abbrev-ref', 'HEAD',
+      ], {
+        cwd: repoPath,
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env: safeGitEnv(),
+      }).trim();
+      if (originalBranch === 'HEAD') originalBranch = null; // detached
+    } catch {
+      originalBranch = null;
+    }
+
+    let failed = 0;
+    for (const branch of branches) {
+      process.stdout.write(`  ${chalk.cyan(branch.padEnd(28))} `);
+      try {
+        const status = await migrateOneBranch(branch, opts);
+        process.stdout.write(`${chalk.green('✓')} ${status}\n`);
+      } catch (err) {
+        failed++;
+        const msg = err instanceof Error ? err.message : String(err);
+        process.stdout.write(`${chalk.red('✗')} ${msg}\n`);
+      }
+    }
+
+    // Restore the original branch so the daemon (which writes to whatever
+    // working tree is currently checked out) continues to write into the
+    // correct cortex on its next sync.
+    if (originalBranch && !opts.dryRun) {
+      try {
+        execFileSync('git', [
+          '-c', 'core.hooksPath=/dev/null',
+          '-c', 'core.fsmonitor=',
+          'switch', '--', originalBranch,
+        ], {
+          cwd: repoPath,
+          encoding: 'utf-8',
+          stdio: ['pipe', 'pipe', 'pipe'],
+          env: safeGitEnv(),
+        });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(chalk.yellow(`\nCould not restore original branch "${originalBranch}": ${msg}`));
+        console.error(chalk.yellow(`  Run 'git switch ${originalBranch}' inside ${repoPath} before the daemon writes.`));
+      }
+    }
+
+    if (failed > 0) {
+      console.error(chalk.red(`\n${failed} branch(es) failed.`));
+      process.exit(1);
+    }
+    console.log(chalk.green('\nDone.'));
+  });

--- a/packages/cli/src/commands/cortex.ts
+++ b/packages/cli/src/commands/cortex.ts
@@ -19,6 +19,7 @@ import {
   getLogPath as getSyncLogPath,
 } from '../lib/auto-sync.js';
 import { validateRepoUrl } from '../lib/repo-url.js';
+import { cortexMigrateLayoutCommand } from './cortex-migrate-layout.js';
 
 function prompt(question: string, defaultValue?: string): Promise<string> {
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
@@ -678,6 +679,8 @@ cortexCommand.addCommand(new Command('migrate')
     console.log(`  ${chalk.dim('•')} ${chalk.bold('think cortex status')}  — confirm the new backend is in place`);
     console.log(`  ${chalk.dim('•')} ${chalk.bold('think sync "test"')}     — verify writes hit ${resolved}`);
   }));
+
+cortexCommand.addCommand(cortexMigrateLayoutCommand);
 
 function listLocalCortexes(): string[] {
   const dir = getIndexDir();

--- a/packages/cli/src/commands/reindex.ts
+++ b/packages/cli/src/commands/reindex.ts
@@ -23,6 +23,7 @@ import { getConfig } from '../lib/config.js';
 import {
   listBranchFiles,
   readFileFromBranch,
+  readCortexFile,
   ensureRepoCloned,
   fetchBranch,
 } from '../lib/git.js';
@@ -44,19 +45,23 @@ export function readAllL1Pages(
   cortexName: string,
   errors: string[],
 ): string[] {
+  // `listBranchFiles` returns basenames of the canonical `<cortex>/` subdir;
+  // the numbered-page filter is unchanged.
   const files = listBranchFiles(cortexName, '.jsonl')
     .filter(f => /^\d{6}\.jsonl$/.test(f))
     .sort();
 
   if (files.length === 0) {
-    // Legacy fallback: single memories.jsonl
+    // Pre-v2 legacy fallback: a single top-level `memories.jsonl`. Use the
+    // top-level read here on purpose — this file never lived in the cortex
+    // subdir.
     const raw = readFileFromBranch(cortexName, 'memories.jsonl');
     return raw ? [raw] : [];
   }
 
   const pages: string[] = [];
   for (const file of files) {
-    const raw = readFileFromBranch(cortexName, file);
+    const raw = readCortexFile(cortexName, file);
     if (raw === null) {
       errors.push(`Could not read ${file} from branch ${cortexName} — skipping page`);
       continue;

--- a/packages/cli/src/lib/git.ts
+++ b/packages/cli/src/lib/git.ts
@@ -144,9 +144,15 @@ export function createOrphanBranch(branchName: string): void {
     // Empty repo — nothing to remove
   }
 
+  // Canonical layout: every cortex file lives under <repo>/<branchName>/...
+  // so the branch tree is self-contained at one subdir, which keeps a future
+  // merge-to-main from colliding across cortices. Use forward slashes for git
+  // arguments (git accepts POSIX paths on every platform).
   const repoPath = getRepoPath();
-  fs.writeFileSync(path.join(repoPath, '000001.jsonl'), '', 'utf-8');
-  runGit(['add', '000001.jsonl']);
+  const cortexDir = path.join(repoPath, branchName);
+  fs.mkdirSync(cortexDir, { recursive: true, mode: 0o700 });
+  fs.writeFileSync(path.join(cortexDir, '000001.jsonl'), '', 'utf-8');
+  runGit(['add', '--', `${branchName}/000001.jsonl`]);
   runGit(['commit', '-m', `init: create cortex ${branchName}`]);
   runGit(['push', '--set-upstream', 'origin', '--', branchName]);
 }
@@ -184,6 +190,37 @@ export function readFileFromBranch(branchName: string, filePath: string): string
   }
 }
 
+/**
+ * Read a file from the cortex subdir on `branchName` (canonical nested layout:
+ * `<branchName>/<fileName>`). Returns null if the file does not exist there.
+ *
+ * Use this in place of `readFileFromBranch(branchName, fileName)` for any read
+ * of cortex content (memory pages, long-term, per-peer retros). The legacy
+ * top-level fallback for `memories.jsonl` (v1 → v2 migration) and the
+ * top-level flat layout (pre-migrate-layout) still exists; callers that need
+ * the legacy fallback should call `readFileFromBranch` explicitly with the
+ * top-level path.
+ */
+export function readCortexFile(branchName: string, fileName: string): string | null {
+  return readFileFromBranch(branchName, `${branchName}/${fileName}`);
+}
+
+/**
+ * Append `newLines` to the canonical cortex file `<branchName>/<targetFile>`
+ * on the branch, then commit and push.
+ *
+ * `targetFile` is the basename (e.g. `"000005.jsonl"`, `"long-term.jsonl"`,
+ * `"alice-retros.jsonl"`); the function prefixes it with `<branchName>/`
+ * internally so callers stay layout-agnostic. The cortex subdir is
+ * mkdir-recursive'd before the append, so brand-new cortices (and cortices
+ * that have not yet been through `think cortex migrate-layout`) just work.
+ *
+ * `memories.jsonl` is preserved as the default for backward compatibility
+ * with the legacy v1 layout, but in the canonical layout it lives at
+ * `<branchName>/memories.jsonl`. The v1 → v2 migration in `migrateToBuckets`
+ * still operates on the top-level legacy file; `migrate-layout` moves the
+ * post-v2 results into the cortex subdir.
+ */
 export function appendAndCommit(
   branchName: string,
   newLines: string[],
@@ -193,7 +230,10 @@ export function appendAndCommit(
 ): void {
   assertSafePositional(branchName, 'branch name');
   const repoPath = getRepoPath();
-  const filePath = path.join(repoPath, targetFile);
+  // POSIX-style slash is what git wants on every platform; path.join uses the
+  // OS separator for the on-disk write, but the staged ref must be POSIX.
+  const stagedPath = `${branchName}/${targetFile}`;
+  const filePath = path.join(repoPath, branchName, targetFile);
 
   try {
     runGit(['switch', '--', branchName]);
@@ -206,10 +246,15 @@ export function appendAndCommit(
 
   pullRebaseOrAbort(branchName);
 
+  // Cortex subdir may not exist yet (first write to a cortex that has not
+  // been through `migrate-layout`, or a brand-new orphan that this process
+  // is the first to write to). Idempotent — safe on every call.
+  fs.mkdirSync(path.dirname(filePath), { recursive: true, mode: 0o700 });
+
   const content = newLines.join('\n') + '\n';
   fs.appendFileSync(filePath, content, 'utf-8');
 
-  runGit(['add', targetFile]);
+  runGit(['add', '--', stagedPath]);
   runGit(['commit', '-m', commitMessage]);
 
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
@@ -260,13 +305,51 @@ export function listLocalBranches(): string[] {
   return output.trim().split('\n').filter(Boolean);
 }
 
+/**
+ * List the immediate children of the canonical cortex subdir
+ * (`origin/<branchName>:<branchName>/`). Returns basenames, e.g.
+ * `["000001.jsonl", "long-term.jsonl", "alice-retros.jsonl"]`.
+ *
+ * If the subdir does not exist on the branch (a cortex that has not yet been
+ * through `migrate-layout`, or a brand-new branch), returns `[]`. Use
+ * `listBranchRootFiles` to introspect the legacy top-level layout.
+ */
 export function listBranchFiles(branchName: string, extension?: string): string[] {
   assertSafePositional(branchName, 'branch name');
   try {
-    // `origin/${branchName}` is a composed ref, not a positional that git
-    // would parse as a flag — a ref like `origin/--foo` is a ref name, not
-    // a --foo option. assertSafePositional still guards the leading-hyphen
-    // case for defense in depth.
+    // `<rev>:<path>` lists the contents of the subdir on the branch. Returns
+    // basenames (no path prefix), so callers' existing pattern matching on
+    // e.g. /^\d{6}\.jsonl$/ continues to work unchanged.
+    const output = runGit([
+      'ls-tree', '--name-only',
+      `origin/${branchName}:${branchName}`,
+    ]);
+    let files = output.split('\n').filter(Boolean);
+    if (extension) {
+      files = files.filter(f => f.endsWith(extension));
+    }
+    return files.sort();
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * List the immediate children of the branch root (`origin/<branchName>:`).
+ *
+ * Used by `cortex migrate-layout` to detect leftover flat-layout files
+ * (pre-AGT-XXX) — `000001.jsonl`, `long-term.jsonl`, `<peer>-retros.jsonl`,
+ * `memories.jsonl` — as well as any non-canonical sibling subdir (e.g.
+ * `hivedb/` on the `cortex/hivedb` branch when the cortex was originally
+ * created with a slashless name).
+ *
+ * Returns basenames; tree entries are returned alongside blob entries since
+ * `ls-tree --name-only` does not distinguish — callers can probe via
+ * `listBranchFiles` if a name turns out to be a tree.
+ */
+export function listBranchRootFiles(branchName: string, extension?: string): string[] {
+  assertSafePositional(branchName, 'branch name');
+  try {
     const output = runGit(['ls-tree', '--name-only', `origin/${branchName}`]);
     let files = output.split('\n').filter(Boolean);
     if (extension) {
@@ -278,12 +361,32 @@ export function listBranchFiles(branchName: string, extension?: string): string[
   }
 }
 
-export function countBranchFileLines(branchName: string, filePath: string): number {
-  const content = readFileFromBranch(branchName, filePath);
+/**
+ * Count the non-empty lines in a cortex file on the branch. `fileName` is the
+ * basename (e.g. `"000001.jsonl"`); the function resolves it under the
+ * canonical `<branchName>/` subdir. Returns 0 when the file is missing or
+ * empty.
+ */
+export function countBranchFileLines(branchName: string, fileName: string): number {
+  const content = readCortexFile(branchName, fileName);
   if (!content) return 0;
   return content.trim().split('\n').filter(Boolean).length;
 }
 
+/**
+ * v1 → v2 migration: legacy top-level `memories.jsonl` becomes the first
+ * bucketed page `000001.jsonl`. In the canonical nested layout the page lands
+ * at `<branchName>/000001.jsonl`; the legacy `memories.jsonl` is *removed*
+ * from the top level so the branch tree ends with one entry per cortex (the
+ * cortex subdir), matching what `migrate-layout` produces for every other
+ * cortex.
+ *
+ * Rollback: if the push fails after the rename+commit, we `reset --hard` to
+ * the pre-migration ref, which restores `memories.jsonl` at the top level
+ * and removes the new nested file. Any caller that needs to retry can run
+ * `cortex migrate-layout` (which is the long-term home for this kind of
+ * one-shot rewrite) instead.
+ */
 export function migrateToBuckets(branchName: string): void {
   assertSafePositional(branchName, 'branch name');
   const repoPath = getRepoPath();
@@ -298,15 +401,19 @@ export function migrateToBuckets(branchName: string): void {
   pullRebaseOrAbort(branchName);
 
   const legacyPath = path.join(repoPath, 'memories.jsonl');
-  const bucketPath = path.join(repoPath, '000001.jsonl');
+  const cortexDir = path.join(repoPath, branchName);
+  const bucketPath = path.join(cortexDir, '000001.jsonl');
 
   if (fs.existsSync(legacyPath) && !fs.existsSync(bucketPath)) {
     // Save pre-migration ref for rollback
     const preMigrationRef = runGit(['rev-parse', 'HEAD']);
 
+    fs.mkdirSync(cortexDir, { recursive: true, mode: 0o700 });
     fs.renameSync(legacyPath, bucketPath);
+    // `add -A` picks up the deleted top-level file and the new nested file
+    // in one shot, which keeps the commit atomic.
     runGit(['add', '-A']);
-    runGit(['commit', '-m', 'migrate: memories.jsonl -> 000001.jsonl']);
+    runGit(['commit', '-m', `migrate: memories.jsonl -> ${branchName}/000001.jsonl`]);
 
     for (let attempt = 1; attempt <= 3; attempt++) {
       try {
@@ -315,8 +422,9 @@ export function migrateToBuckets(branchName: string): void {
       } catch {
         if (attempt === 3) {
           // Rollback to pre-migration commit. That commit has memories.jsonl
-          // (the rename to 000001.jsonl happened after it), so --hard reset
-          // restores memories.jsonl and removes 000001.jsonl from working tree.
+          // at the top level (the move into <branch>/000001.jsonl happened
+          // after it), so --hard reset restores the top-level file and
+          // removes the nested copy.
           try { runGit(['reset', '--hard', preMigrationRef]); } catch { /* best effort */ }
           throw new Error('Migration push failed after 3 attempts — local commit rolled back');
         }

--- a/packages/cli/src/sync/git-adapter.ts
+++ b/packages/cli/src/sync/git-adapter.ts
@@ -3,6 +3,7 @@ import {
   ensureRepoCloned,
   fetchBranch,
   readFileFromBranch,
+  readCortexFile,
   appendAndCommit,
   createOrphanBranch,
   ensureRemoteBranch,
@@ -51,6 +52,10 @@ export class GitSyncAdapter implements SyncAdapter {
   private ensureMigrated(cortex: string, branchFiles: string[]): void {
     const hasNumbered = branchFiles.some(f => /^\d{6}\.jsonl$/.test(f));
     if (!hasNumbered) {
+      // `memories.jsonl` is the pre-v2 legacy filename and only ever existed
+      // at the branch root, so this read deliberately uses the top-level
+      // `readFileFromBranch` (not `readCortexFile`). The migration helper
+      // moves it into the canonical `<cortex>/000001.jsonl` location.
       const hasLegacy = readFileFromBranch(cortex, 'memories.jsonl') !== null;
       if (hasLegacy) {
         migrateToBuckets(cortex);
@@ -270,7 +275,7 @@ export class GitSyncAdapter implements SyncAdapter {
     let touched = false;
 
     for (const file of retroFiles) {
-      const raw = readFileFromBranch(cortex, file);
+      const raw = readCortexFile(cortex, file);
       if (raw === null) {
         result.errors.push(`Could not read ${file} from branch: git read returned null`);
         continue;
@@ -391,7 +396,9 @@ export class GitSyncAdapter implements SyncAdapter {
       .sort();
 
     if (files.length === 0) {
-      // Legacy fallback: try memories.jsonl
+      // Legacy fallback: try top-level memories.jsonl (pre-v2 layout). This
+      // is the only branch where a non-canonical top-level read is correct;
+      // every other read goes through `readCortexFile`.
       const memoriesRaw = readFileFromBranch(cortex, 'memories.jsonl') ?? '';
       if (memoriesRaw) {
         this.processMemories(cortex, memoriesRaw, result);
@@ -423,7 +430,7 @@ export class GitSyncAdapter implements SyncAdapter {
     // Stop at the first read failure — don't advance cursor past a gap.
     let lastReadFile: string | null = null;
     for (const file of filesToRead) {
-      const raw = readFileFromBranch(cortex, file);
+      const raw = readCortexFile(cortex, file);
       if (raw === null) {
         // Read failure — stop here. Cursor stays at lastReadFile so this
         // file and all subsequent files get retried on next pull.
@@ -442,7 +449,7 @@ export class GitSyncAdapter implements SyncAdapter {
   }
 
   private pullLongTermEvents(cortex: string, result: SyncResult): void {
-    const raw = readFileFromBranch(cortex, LONG_TERM_FILE);
+    const raw = readCortexFile(cortex, LONG_TERM_FILE);
     if (raw === null || !raw.trim()) return; // file doesn't exist or is empty
 
     for (const line of raw.trim().split('\n')) {

--- a/packages/cli/tests/commands/reindex.test.ts
+++ b/packages/cli/tests/commands/reindex.test.ts
@@ -31,6 +31,7 @@ vi.mock('../../src/lib/git.js', () => ({
   fetchBranch: vi.fn(),
   listBranchFiles: vi.fn().mockReturnValue([]),
   readFileFromBranch: vi.fn().mockReturnValue(null),
+  readCortexFile: vi.fn().mockReturnValue(null),
 }));
 
 import * as gitLib from '../../src/lib/git.js';
@@ -55,18 +56,23 @@ function mockL1Pages(pages: string[]): void {
   if (pages.length === 0) {
     vi.mocked(gitLib.listBranchFiles).mockReturnValue([]);
     vi.mocked(gitLib.readFileFromBranch).mockReturnValue(null);
+    vi.mocked(gitLib.readCortexFile).mockReturnValue(null);
     return;
   }
   const fileNames = pages.map((_, i) =>
     String(i + 1).padStart(6, '0') + '.jsonl'
   );
   vi.mocked(gitLib.listBranchFiles).mockReturnValue(fileNames);
-  vi.mocked(gitLib.readFileFromBranch).mockImplementation(
+  // readCortexFile is the cortex-aware reader used by readAllL1Pages for the
+  // nested layout. readFileFromBranch stays mocked for the legacy
+  // `memories.jsonl` top-level fallback path.
+  vi.mocked(gitLib.readCortexFile).mockImplementation(
     (_cortex: string, file: string) => {
       const idx = fileNames.indexOf(file);
       return idx >= 0 ? pages[idx] : null;
     }
   );
+  vi.mocked(gitLib.readFileFromBranch).mockReturnValue(null);
 }
 
 // ─── DB query helpers ─────────────────────────────────────────────────────────

--- a/packages/cli/tests/daemon/embed-model-check.test.ts
+++ b/packages/cli/tests/daemon/embed-model-check.test.ts
@@ -34,6 +34,7 @@ vi.mock('../../src/lib/git.js', () => ({
   fetchBranch: vi.fn(),
   listBranchFiles: vi.fn().mockReturnValue([]),
   readFileFromBranch: vi.fn().mockReturnValue(null),
+  readCortexFile: vi.fn().mockReturnValue(null),
   listLocalBranches: vi.fn().mockReturnValue([]),
 }));
 
@@ -54,16 +55,21 @@ function mockL1Pages(pages: string[]): void {
   if (pages.length === 0) {
     vi.mocked(gitLib.listBranchFiles).mockReturnValue([]);
     vi.mocked(gitLib.readFileFromBranch).mockReturnValue(null);
+    vi.mocked(gitLib.readCortexFile).mockReturnValue(null);
     return;
   }
   const fileNames = pages.map((_, i) => String(i + 1).padStart(6, '0') + '.jsonl');
   vi.mocked(gitLib.listBranchFiles).mockReturnValue(fileNames);
-  vi.mocked(gitLib.readFileFromBranch).mockImplementation(
+  // reindexOneCortex → readAllL1Pages reads via readCortexFile in the nested
+  // layout; readFileFromBranch is still mocked to null so the legacy
+  // memories.jsonl fallback path doesn't fire here.
+  vi.mocked(gitLib.readCortexFile).mockImplementation(
     (_cortex: string, file: string) => {
       const idx = fileNames.indexOf(file);
       return idx >= 0 ? pages[idx] : null;
     }
   );
+  vi.mocked(gitLib.readFileFromBranch).mockReturnValue(null);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Canonicalize the cortex on-disk layout to `<repo>/<branch>/<file>` so every cortex's files (memory pages, long-term, per-peer retros) live under a single branch-scoped subdir. Two write paths previously disagreed — the legacy `git-adapter` wrote flat at the branch root, while the newer daemon + proxy paths wrote nested — leaving branches like `cortex/engineering` with files in both locations and `reindex` silently dropping the nested ones on `--force` (non-recursive `ls-tree`).
- New `think cortex migrate-layout [cortex] [--dry-run] [--no-push]` does the one-shot migration: flat pages keep their numbers, existing nested pages get renumbered past them to keep a linear history, and non-canonical sibling subdirs (e.g. `hivedb/` on the `cortex/hivedb` branch) fold into canonical. The command restores the originally-checked-out branch at the end so the daemon (which writes to whatever branch is currently checked out) keeps landing on the right tree.
- All read sites switched from `readFileFromBranch` to a new `readCortexFile` helper that resolves the canonical subdir; the legacy top-level `memories.jsonl` fallback is the only remaining literal top-level read.

## Test plan
- [x] `vitest` — all 1145 cases pass (mocks updated in `tests/commands/reindex.test.ts` and `tests/daemon/embed-model-check.test.ts` to include the new `readCortexFile` export).
- [x] Ran `think cortex migrate-layout --dry-run` and then live on the Anglepoint-Inc/hivedb remote against `cortex/engineering` (6 files moved/renumbered) and `cortex/hivedb` (2 files moved). `main` correctly reported "already nested" (no `.jsonl` to migrate).
- [x] `think recall "git" --limit 3` on migrated `cortex/engineering` returns hits as expected.
- [x] `think reindex cortex/engineering` rebuilds 4018 entries across the 5 pages in 20.9s — no drops.
- [x] `think sync "<test>"` lands the new entry on `cortex/engineering/000005.jsonl`, debouncer commits and pushes to the right branch.

## Follow-up
The daemon writes to whatever branch is checked out in `~/.think/repo` rather than `git switch`-ing to the cortex branch first. The new `migrate-layout` restores the original branch at the end as a band-aid, but the underlying behavior should be fixed in a separate ticket — any future workflow that changes the checked-out branch out from under the daemon would write to the wrong tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)