### PR TITLE
fix(sync): hide git console window on Windows; key L2 on explicit id

### DIFF
--- a/packages/cli/src/commands/reindex.ts
+++ b/packages/cli/src/commands/reindex.ts
@@ -28,7 +28,7 @@ import {
   fetchBranch,
 } from '../lib/git.js';
 import { parseMemoriesJsonl } from '../lib/curator.js';
-import { deterministicId } from '../lib/deterministic-id.js';
+import { resolveMemoryId } from '../lib/deterministic-id.js';
 import { getCortexDb, closeCortexDb } from '../db/engrams.js';
 import { recomputeActivitySeq } from '../db/activity-seq.js';
 import embed, { EMBEDDING_MODEL_NAME } from '../lib/embed.js';
@@ -147,8 +147,10 @@ export async function reindexOneCortex(
     const entries = parseMemoriesJsonl(page);
 
     for (const entry of entries) {
-      // Compute deterministic id matching how sync adapters produce it
-      const id = deterministicId(entry.ts, entry.author, entry.content);
+      // L2 key: explicit id when present, deterministic fallback for legacy
+      // lines (see resolveMemoryId). Keeps reindex idempotent against the
+      // daemon pull-loop rather than duplicating rows under a second key.
+      const id = resolveMemoryId(entry);
       total++;
 
       // Embed — errors are non-fatal; log and continue

--- a/packages/cli/src/lib/curator.ts
+++ b/packages/cli/src/lib/curator.ts
@@ -15,6 +15,14 @@ export type EntryKind = 'memory' | 'retro' | 'event';
 const ENTRY_KINDS: ReadonlySet<EntryKind> = new Set(['memory', 'retro', 'event']);
 
 export interface MemoryEntry {
+  /**
+   * The memory's stable identity as written in the JSONL. This is the key the
+   * daemon pull-loop ingests under and the key supersedes/compacted_from
+   * reference — so reindex/git-adapter MUST key on it too (falling back to a
+   * deterministic id only for legacy id-less lines). Optional because pre-v7
+   * legacy lines lack it.
+   */
+  id?: string;
   ts: string;
   author: string;
   content: string;
@@ -397,6 +405,7 @@ export function parseMemoriesJsonl(content: string): MemoryEntry[] {
           ? parsed.topics.filter((t: unknown): t is string => typeof t === 'string')
           : [];
         entries.push({
+          id: typeof parsed.id === 'string' && parsed.id ? parsed.id : undefined,
           ts: parsed.ts ?? '',
           author: parsed.author ?? 'unknown',
           content: parsed.content,

--- a/packages/cli/src/lib/deterministic-id.ts
+++ b/packages/cli/src/lib/deterministic-id.ts
@@ -10,6 +10,25 @@ export function deterministicId(ts: string, author: string, content: string): st
   return uuidv5(hash, THINK_UUID_NAMESPACE);
 }
 
+/**
+ * The L2 primary key for a memory entry: its explicit `id` when present — the
+ * key the daemon pull-loop ingests under and that `supersedes`/`compacted_from`
+ * point to — falling back to a content-derived {@link deterministicId} only for
+ * legacy pre-v7 lines that have no `id`. All paths that index memories into L2
+ * (reindex, git-adapter) must route through this so a reindex is idempotent
+ * against daemon-ingested rows instead of duplicating them under a second key.
+ */
+export function resolveMemoryId(entry: {
+  id?: string;
+  ts: string;
+  author: string;
+  content: string;
+}): string {
+  return typeof entry.id === 'string' && entry.id
+    ? entry.id
+    : deterministicId(entry.ts, entry.author, entry.content);
+}
+
 // Separate namespace-prefixed hash for long-term events so they can't
 // collide with memory IDs even if ts/author/content happen to match.
 export function deterministicEventId(ts: string, author: string, title: string, content: string): string {

--- a/packages/cli/src/lib/git.ts
+++ b/packages/cli/src/lib/git.ts
@@ -39,6 +39,10 @@ function runGit(args: string[], cwd?: string): string {
     encoding: 'utf-8',
     stdio: ['pipe', 'pipe', 'pipe'],
     env: safeGitEnv(),
+    // On Windows, spawning git without this flashes a console window per call.
+    // The daemon makes many git calls (pull/push/show); during a backfill that's
+    // a storm of focus-stealing windows. Harmless no-op on macOS/Linux.
+    windowsHide: true,
   }).trim();
 }
 
@@ -248,6 +252,7 @@ export function ensureRepoCloned(): void {
     encoding: 'utf-8',
     stdio: ['pipe', 'pipe', 'pipe'],
     env: safeGitEnv(),
+    windowsHide: true, // suppress the per-call console window on Windows
   });
   // Fresh clone: stamp the always-effective local union driver so the very
   // first write's pull-rebase can reconcile a divergent page.

--- a/packages/cli/src/sync/git-adapter.ts
+++ b/packages/cli/src/sync/git-adapter.ts
@@ -32,7 +32,7 @@ import {
 } from '../db/retro-queries.js';
 import { serializeRetroForSync, parseRetrosJsonl } from '../lib/retro-jsonl.js';
 import { getConfig, getPeerId } from '../lib/config.js';
-import { deterministicId, deterministicEventId } from '../lib/deterministic-id.js';
+import { deterministicEventId, resolveMemoryId } from '../lib/deterministic-id.js';
 import { validateEngramContent } from '../lib/sanitize.js';
 import type { SyncAdapter, SyncResult } from './types.js';
 
@@ -349,7 +349,11 @@ export class GitSyncAdapter implements SyncAdapter {
       // deletes are local-only and do not propagate.
       if (m.deleted_at) continue;
 
-      const id = deterministicId(m.ts, m.author, m.content);
+      // L2 key: explicit id when present, deterministic fallback for legacy
+      // lines (see resolveMemoryId). Recomputing a deterministic id here (as
+      // this used to) keyed L2 under an id nothing references — duplicating
+      // pull-loop rows and breaking supersession.
+      const id = resolveMemoryId(m);
 
       const { content: sanitizedContent, warnings } = validateEngramContent(m.content);
       if (warnings.length > 0) {
@@ -564,7 +568,7 @@ export class GitSyncAdapter implements SyncAdapter {
       execFileSync(
         'git',
         ['-c', 'core.hooksPath=/dev/null', 'ls-remote', '--exit-code', '--', repo, 'HEAD'],
-        { stdio: ['ignore', 'pipe', 'pipe'], timeout: 5000, env: { ...process.env, GIT_TERMINAL_PROMPT: '0' } },
+        { stdio: ['ignore', 'pipe', 'pipe'], timeout: 5000, windowsHide: true, env: { ...process.env, GIT_TERMINAL_PROMPT: '0' } },
       );
       return true;
     } catch (err) {


### PR DESCRIPTION
Two related sync-layer fixes. Opened as a PR for ingestion — **please land via `stamp merge` locally**, not the GitHub merge button (GitHub is the read-only mirror). Already passed a local `stamp review` (security/standards/product all approved) + build/test/typecheck on rebased-onto-main.

## 1. `windowsHide: true` on every git spawn
On Windows, `execFileSync('git', …)` without `windowsHide` flashes a console window **per call**. The daemon makes many git calls (pull/push/show); during a backfill that's a storm of focus-stealing windows that blocks the user entirely. Added to all three spawn sites: `runGit` (covers all its callers), `ensureRepoCloned`, and `git-adapter` `isReachable`. No-op on macOS/Linux.

## 2. Key L2 on the explicit `id` (not a recomputed deterministic id)
`parseMemoriesJsonl` dropped the `id` field, so `reindex` and `git-adapter` recomputed a **deterministic** id and keyed L2 under an id nothing references — while the daemon pull-loop keys on the **explicit** `id`. Consequences:
- **Duplicates:** every daemon push→pull re-ingested the touched page under the explicit key alongside the deterministic one (observed: a clean reindex + one push→pull cycle ballooned a live cortex with thousands of dup rows).
- **Broken supersession:** `supersession/apply.ts` does `WHERE id = <supersedes>`, and `supersedes`/`compacted_from` reference explicit ids — which were never the L2 key for reindexed/onboarded memories, so superseded versions silently survived in recall.

Fix: `MemoryEntry` carries an optional `id`; `parseMemoriesJsonl` preserves it; a shared `resolveMemoryId()` helper (explicit id, deterministic fallback for legacy id-less lines) is used by both `reindex` and `git-adapter`.

## ⚠️ Migration
Existing L2 indexes were keyed deterministically. After upgrading, run **`think reindex <cortex> --force` once** so the rebuild re-keys to explicit ids — then the daemon's ongoing pulls are idempotent and supersession resolves.

## Heads-up: pre-existing flaky test
`tests/sync/git-adapter.test.ts > "two peers converge when both write retros"` is **flaky on `main`** (~50%, reproduced with no changes) — it intermittently fails the merge gate. Unrelated to this change (retro path), but worth a separate fix/quarantine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)