### PR TITLE
feat(slack): ingest huddle transcripts from channel-attached files

### DIFF
--- a/packages/cli/src/serve/connectors/slack.ts
+++ b/packages/cli/src/serve/connectors/slack.ts
@@ -126,6 +126,25 @@ interface SlackReaction {
   count?: number;
 }
 
+/**
+ * Subset of a Slack file object as it rides inline on `conversations.history`
+ * / `conversations.replies` messages. Slack includes `url_private*` on the
+ * inline object, so reading a file's content needs no extra `files.info` hop.
+ */
+interface SlackFile {
+  id: string;
+  /** Filename incl. extension, e.g. `EEP - data strategy.vtt`. */
+  name?: string;
+  /** Human title; for AI-notes canvases this is `:headphones: Huddle notes: …`. */
+  title?: string;
+  /** Slack's coarse type bucket: `text`, `quip` (canvas), `huddle_transcript`, … */
+  filetype?: string;
+  mimetype?: string;
+  /** Authenticated download URLs on `files.slack.com`. */
+  url_private?: string;
+  url_private_download?: string;
+}
+
 interface SlackMessage {
   ts: string;
   thread_ts?: string;
@@ -135,6 +154,7 @@ interface SlackMessage {
   text?: string;
   reactions?: SlackReaction[];
   subtype?: string;
+  files?: SlackFile[];
 }
 
 interface SlackChannel {
@@ -148,6 +168,105 @@ const DEFAULT_CLOSED_THREAD_MEMORY = 500;
 const DEFAULT_CLOSING_REACTION = 'lock';
 const HISTORY_PAGE_SIZE = 100;
 const CHANNELS_PAGE_SIZE = 200;
+
+// Cap the transcript text we ship in a single event's payload. The curator
+// pretty-prints the whole payload into one prompt, so an unbounded multi-hour
+// transcript could blow the model's context. A half-MB cap (~125k tokens) is
+// generous for real huddles; on overflow we slice and flag `truncated: true`.
+const MAX_TRANSCRIPT_CHARS = 500_000;
+
+/**
+ * Transcript-bearing files that appear in a channel after a meeting/huddle:
+ *
+ *   - `verbatim`: a Slack-auto-posted `.vtt`/`.srt` transcript (speaker-labeled,
+ *     timestamped). This is the high-fidelity artifact — present only when the
+ *     workspace had *transcription* (not just AI notes) enabled for the call.
+ *   - `summary`: the AI huddle-notes `quip` canvas (topics/decisions/action
+ *     items). Always produced for an AI-notes huddle, but lossy — a fallback
+ *     when no verbatim transcript exists.
+ *
+ * NOTE: Slack's native `huddle_transcript` file object is deliberately NOT
+ * matched here. It is shared only into the canvas's internal channel, so a bot
+ * token 302s on its download. The in-channel `.vtt` is the reachable artifact.
+ */
+type TranscriptFidelity = 'verbatim' | 'summary';
+type TranscriptFormat = 'vtt' | 'srt' | 'canvas';
+
+interface ClassifiedTranscript {
+  file: SlackFile;
+  fidelity: TranscriptFidelity;
+  format: TranscriptFormat;
+}
+
+/** Classify a file as a transcript artifact, or `null` if it isn't one. */
+function classifyTranscriptFile(f: SlackFile): ClassifiedTranscript | null {
+  const name = (f.name ?? '').toLowerCase();
+  if (name.endsWith('.vtt')) return { file: f, fidelity: 'verbatim', format: 'vtt' };
+  if (name.endsWith('.srt')) return { file: f, fidelity: 'verbatim', format: 'srt' };
+  // AI huddle-notes canvas. Match on the title marker rather than bare
+  // `filetype === 'quip'` so we don't sweep in unrelated canvases someone
+  // happened to attach to a settled thread.
+  if (f.filetype === 'quip' && /huddle notes/i.test(f.title ?? '')) {
+    return { file: f, fidelity: 'summary', format: 'canvas' };
+  }
+  return null;
+}
+
+/**
+ * Normalize a WebVTT transcript to speaker-turn plaintext. Slack's huddle
+ * `.vtt` uses `<v Speaker Name>text</v>` voice spans with uuid cue ids and
+ * `00:00:12.426 --> 00:00:16.339` timing lines; we keep only the spoken text,
+ * collapse it to `Speaker: text` turns, and merge consecutive same-speaker
+ * cues so the curator reads dialogue, not subtitle fragments.
+ */
+export function vttToTranscript(vtt: string): string {
+  const lines = vtt.split(/\r?\n/);
+  const out: string[] = [];
+  let lastSpeaker: string | null = null;
+  for (const line of lines) {
+    const m = line.match(/^<v\s+([^>]+)>([\s\S]*?)<\/v>\s*$/);
+    if (!m) continue;
+    const speaker = m[1].trim();
+    const text = m[2].trim();
+    if (!text) continue;
+    if (speaker === lastSpeaker && out.length > 0) {
+      out[out.length - 1] += ' ' + text;
+    } else {
+      out.push(`${speaker}: ${text}`);
+      lastSpeaker = speaker;
+    }
+  }
+  // Fallback for VTT without voice spans: drop the header, cue-id, and timing
+  // lines and keep the remaining caption text.
+  if (out.length === 0) {
+    for (const line of lines) {
+      const t = line.trim();
+      if (!t || t === 'WEBVTT' || t.includes('-->')) continue;
+      if (/^[0-9a-f-]+(\/\d+-?\d*)?$/i.test(t)) continue; // cue identifier
+      out.push(t);
+    }
+  }
+  return out.join('\n');
+}
+
+/** Strip an AI-notes canvas's HTML to readable plaintext. */
+export function canvasHtmlToText(html: string): string {
+  return html
+    .replace(/<style[\s\S]*?<\/style>/gi, '')
+    .replace(/<script[\s\S]*?<\/script>/gi, '')
+    .replace(/<\/(p|div|li|h[1-6]|tr)>/gi, '\n')
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<[^>]+>/g, '')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&#39;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
 
 function normalizeReactionName(raw: string): string {
   // Operators sometimes paste `:lock:` from Slack's emoji picker. Slack's
@@ -307,18 +426,13 @@ export function createSlackConnector(
     return new Date(secs * 1000).toISOString();
   }
 
-  async function emitForClosedThread(
-    token: string,
+  function buildClosedThreadEvent(
     workspace: string,
     channel: SlackChannel,
     root: SlackMessage,
-  ): Promise<EventInput> {
-    const { messages: thread, hasMore } = await listThreadReplies(token, channel.id, root.ts);
-    // `conversations.replies` returns the root as the first element plus
-    // every reply, in chronological order. Empty array would be a Slack
-    // bug, but treat defensively: if empty, fall back to the root we
-    // already have so the event still ships.
-    const messages = thread.length > 0 ? thread : [root];
+    messages: SlackMessage[],
+    hasMore: boolean,
+  ): EventInput {
     const participants = collectParticipants(messages);
     const firstTs = messages[0]?.ts ?? root.ts;
     const lastTs = messages[messages.length - 1]?.ts ?? root.ts;
@@ -357,6 +471,119 @@ export function createSlackConnector(
     };
   }
 
+  /**
+   * Download a file's content from `files.slack.com`. Returns the body text on
+   * a clean 200, or `null` on any non-200. `redirect: 'manual'` is the crux:
+   * a file the bot can't access (e.g. Slack's native `huddle_transcript`, which
+   * is shared only into the canvas's internal channel) responds `302` toward a
+   * login page — without `manual` we'd silently follow it and parse the login
+   * HTML as if it were the transcript. Treating any non-200 as "skip" keeps
+   * those walled files from poisoning a memory.
+   *
+   * NOTE: this bypasses `slackFetch` on purpose — that helper expects the
+   * `api.slack.com` JSON envelope (`{ ok, ... }`), whereas file bodies are raw
+   * bytes served from a different host.
+   */
+  async function fetchFileContent(token: string, file: SlackFile): Promise<string | null> {
+    const url = file.url_private_download ?? file.url_private;
+    if (!url) return null;
+    let res: Response;
+    try {
+      res = await fetchImpl(url, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'User-Agent': 'open-think-server',
+        },
+        redirect: 'manual',
+      });
+    } catch {
+      return null;
+    }
+    if (res.status !== 200) return null;
+    try {
+      return await res.text();
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Emit one terminal `huddle.transcript` event per transcript file attached to
+   * a settled thread (root + replies). When a thread carries both a verbatim
+   * `.vtt` and the AI-notes summary canvas, the verbatim wins and the canvas is
+   * dropped — we'd rather the curator segment the real dialogue than Slack's
+   * lossy recap. Files the bot can't download (`fetchFileContent` → null) are
+   * skipped silently, so a walled native transcript never blocks the others.
+   */
+  async function emitTranscriptsForThread(
+    token: string,
+    workspace: string,
+    channel: SlackChannel,
+    root: SlackMessage,
+    messages: SlackMessage[],
+  ): Promise<EventInput[]> {
+    // Collect transcript-classified files across the whole thread, deduped by
+    // file id (Slack can echo the same file on multiple share records).
+    const found = new Map<string, ClassifiedTranscript>();
+    for (const m of messages) {
+      for (const f of m.files ?? []) {
+        const classified = classifyTranscriptFile(f);
+        if (classified && !found.has(f.id)) found.set(f.id, classified);
+      }
+    }
+    if (found.size === 0) return [];
+
+    const all = [...found.values()];
+    const verbatim = all.filter((t) => t.fidelity === 'verbatim');
+    const picks = verbatim.length > 0 ? verbatim : all;
+
+    const events: EventInput[] = [];
+    for (const pick of picks) {
+      const raw = await fetchFileContent(token, pick.file);
+      if (raw === null) continue; // walled / inaccessible → skip cleanly
+      let transcript =
+        pick.format === 'vtt'
+          ? vttToTranscript(raw)
+          : pick.format === 'srt'
+            ? raw
+            : canvasHtmlToText(raw);
+      const truncated = transcript.length > MAX_TRANSCRIPT_CHARS;
+      if (truncated) transcript = transcript.slice(0, MAX_TRANSCRIPT_CHARS);
+      if (!transcript.trim()) continue; // nothing usable extracted
+
+      // Key the episode on the file id (not the thread root) so the same
+      // huddle's transcript and any in-channel discussion stay distinct
+      // memories, and a re-poll `INSERT OR IGNORE`s against the existing row.
+      const episodeKey = `slack:huddle:${workspace}:${channel.id}:${pick.file.id}`;
+      events.push({
+        id: episodeKey + ':transcript',
+        episodeKey,
+        terminal: true,
+        occurredAt: tsToIso(root.ts) ?? undefined,
+        payload: JSON.stringify({
+          kind: 'huddle.transcript',
+          // 'verbatim' (real `.vtt`/`.srt`) vs 'summary' (AI-notes canvas).
+          fidelity: pick.fidelity,
+          format: pick.format,
+          workspace,
+          channel_id: channel.id,
+          channel_name: channel.name ?? null,
+          title: pick.file.title ?? pick.file.name ?? null,
+          thread_ts: root.ts,
+          closing_reaction: closingReaction,
+          participants: collectParticipants(messages),
+          // The curator's primary source text — segmented into per-topic
+          // memories exactly like a meeting transcript.
+          transcript,
+          truncated,
+          started_at: tsToIso(root.ts),
+          final_state: 'closed',
+        }),
+      });
+    }
+    return events;
+  }
+
   async function poll(
     ctx: PollContext<SlackCursor>,
   ): Promise<PollResult<SlackCursor>> {
@@ -381,8 +608,14 @@ export function createSlackConnector(
         if (!hasClosingReaction(msg)) continue;
         const episodeKey = `slack:${workspace}:${ch.id}:${msg.ts}`;
         if (emitted.has(episodeKey)) continue;
-        const evt = await emitForClosedThread(token, workspace, ch, msg);
-        events.push(evt);
+        // Fetch the thread once, then feed both the closed-thread event and the
+        // transcript scan. `conversations.replies` returns the root first then
+        // replies in order; an empty array would be a Slack bug, so fall back
+        // to the root we already hold.
+        const { messages: thread, hasMore } = await listThreadReplies(token, ch.id, msg.ts);
+        const threadMessages = thread.length > 0 ? thread : [msg];
+        events.push(buildClosedThreadEvent(workspace, ch, msg, threadMessages, hasMore));
+        events.push(...(await emitTranscriptsForThread(token, workspace, ch, msg, threadMessages)));
         emitted.add(episodeKey);
       }
     }

--- a/packages/cli/tests/serve/connectors/slack.test.ts
+++ b/packages/cli/tests/serve/connectors/slack.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from 'vitest';
 import {
   createSlackConnector,
   SlackRateLimitError,
+  vttToTranscript,
+  canvasHtmlToText,
   type FetchFn,
   type SlackCursor,
 } from '../../../src/serve/connectors/slack.js';
@@ -26,7 +28,9 @@ import {
 interface CannedResponse {
   status?: number;
   headers?: Record<string, string>;
-  body: unknown;
+  body?: unknown;
+  /** Raw response body (for file downloads). Takes precedence over `body`. */
+  text?: string;
 }
 
 interface MockFetchOptions {
@@ -43,10 +47,17 @@ function makeFetch(opts: MockFetchOptions): FetchFn {
       throw new Error(`mock fetch: no route matched ${u}`);
     }
     const status = route.response.status ?? 200;
+    const isRaw = route.response.text !== undefined;
     const headers = new Headers(route.response.headers ?? {});
-    if (!headers.has('content-type')) headers.set('content-type', 'application/json');
-    const bodyText =
-      route.response.body === undefined ? '' : JSON.stringify(route.response.body);
+    if (!headers.has('content-type')) {
+      headers.set('content-type', isRaw ? 'text/plain' : 'application/json');
+    }
+    const bodyText = isRaw
+      ? (route.response.text as string)
+      : route.response.body === undefined
+        ? ''
+        : JSON.stringify(route.response.body);
+    // 204/205/304 forbid a body; everything we mock (incl. 302) allows one.
     return new Response(bodyText, { status, headers });
   };
 }
@@ -811,5 +822,250 @@ describe('createSlackConnector.verifyCredential', () => {
     const r = await connector.verifyCredential!(SECRET);
     expect(r.ok).toBe(false);
     expect(JSON.stringify(r)).not.toContain(SECRET);
+  });
+});
+
+describe('createSlackConnector — huddle transcript ingestion', () => {
+  const FILE_BASE = 'https://files.slack.com/files-pri';
+
+  // Two consecutive Alice cues exercise same-speaker merging; Bob starts a new
+  // turn. Cue ids + timing lines must be stripped.
+  const VTT = [
+    'WEBVTT',
+    '',
+    'abc-1/0-0',
+    '00:00:01.000 --> 00:00:03.000',
+    '<v Alice>Hi everyone, let us start.</v>',
+    '',
+    'abc-1/1-0',
+    '00:00:03.500 --> 00:00:05.000',
+    '<v Alice>We are deciding the cache TTL.</v>',
+    '',
+    'abc-1/2-0',
+    '00:00:05.500 --> 00:00:07.000',
+    '<v Bob>Sixty seconds works for me.</v>',
+  ].join('\n');
+
+  const CANVAS_HTML =
+    '<div class="quip-canvas-content"><h1>Huddle notes</h1>' +
+    '<p>AI took notes from 2:00 - 2:47 PM.</p>' +
+    '<h2>Summary</h2><ul><li>Decided cache TTL is 60s.</li></ul></div>';
+
+  const ROOT_TS = '1718000000.000100';
+
+  /** Build the standard mock: a `:lock:`-reacted huddle root whose thread
+   * reply carries the supplied files. `fileRoutes` serves their downloads. */
+  function buildFetch(files: unknown[], fileRoutes: MockFetchOptions['routes']) {
+    return makeFetch({
+      routes: [
+        {
+          match: matchMethod('users.conversations'),
+          response: { body: { ok: true, channels: [{ id: 'C01', name: 'planning' }] } },
+        },
+        {
+          match: matchMethod('conversations.history'),
+          response: {
+            body: {
+              ok: true,
+              messages: [
+                {
+                  ts: ROOT_TS,
+                  user: 'U_ALICE',
+                  text: 'huddle ended',
+                  reactions: [{ name: 'lock', users: ['U_ALICE'], count: 1 }],
+                },
+              ],
+            },
+          },
+        },
+        {
+          match: matchMethod('conversations.replies'),
+          response: {
+            body: {
+              ok: true,
+              messages: [
+                {
+                  ts: ROOT_TS,
+                  user: 'U_ALICE',
+                  text: 'huddle ended',
+                  reactions: [{ name: 'lock', users: ['U_ALICE'], count: 1 }],
+                  files,
+                },
+              ],
+            },
+          },
+        },
+        ...fileRoutes,
+      ],
+    });
+  }
+
+  function transcriptsOf(events: Array<{ payload: unknown }>) {
+    return events.filter(
+      (e) => (JSON.parse(e.payload as string) as { kind: string }).kind === 'huddle.transcript',
+    );
+  }
+
+  it('emits a verbatim huddle.transcript event for an attached .vtt', async () => {
+    const fetchImpl = buildFetch(
+      [
+        {
+          id: 'F_VTT',
+          name: 'standup.vtt',
+          filetype: 'text',
+          mimetype: 'text/plain',
+          url_private_download: `${FILE_BASE}/T-F_VTT/download/standup.vtt`,
+        },
+      ],
+      [{ match: (u) => u.includes('F_VTT'), response: { text: VTT } }],
+    );
+    const connector = createSlackConnector({ fetchImpl, closingReaction: 'lock' });
+    const result = await connector.poll({ subscription: SUB, credential: TOKEN, cursor: null });
+
+    const transcripts = transcriptsOf(result.events);
+    expect(transcripts).toHaveLength(1);
+    const evt = transcripts[0];
+    expect(evt.episodeKey).toBe('slack:huddle:acme:C01:F_VTT');
+    expect(evt.id).toBe('slack:huddle:acme:C01:F_VTT:transcript');
+    expect(evt.terminal).toBe(true);
+    const p = JSON.parse(evt.payload as string) as {
+      fidelity: string;
+      format: string;
+      channel_id: string;
+      transcript: string;
+      truncated: boolean;
+    };
+    expect(p.fidelity).toBe('verbatim');
+    expect(p.format).toBe('vtt');
+    expect(p.channel_id).toBe('C01');
+    expect(p.truncated).toBe(false);
+    // Same-speaker cues merged into one turn; Bob a separate turn.
+    expect(p.transcript).toBe(
+      'Alice: Hi everyone, let us start. We are deciding the cache TTL.\nBob: Sixty seconds works for me.',
+    );
+    // The closed-thread event is still emitted alongside it.
+    expect(result.events.length).toBe(2);
+  });
+
+  it('skips a transcript file the bot cannot download (302 → login)', async () => {
+    const fetchImpl = buildFetch(
+      [
+        {
+          id: 'F_WALLED',
+          name: 'huddle.vtt',
+          filetype: 'text',
+          url_private_download: `${FILE_BASE}/T-F_WALLED/download/huddle.vtt`,
+        },
+      ],
+      [{ match: (u) => u.includes('F_WALLED'), response: { status: 302, text: '<html>login</html>' } }],
+    );
+    const connector = createSlackConnector({ fetchImpl, closingReaction: 'lock' });
+    const result = await connector.poll({ subscription: SUB, credential: TOKEN, cursor: null });
+
+    // No transcript event — but the closed-thread event still ships.
+    expect(transcriptsOf(result.events)).toHaveLength(0);
+    expect(result.events).toHaveLength(1);
+  });
+
+  it('falls back to the AI-notes canvas (summary) when no verbatim transcript exists', async () => {
+    const fetchImpl = buildFetch(
+      [
+        {
+          id: 'F_CANVAS',
+          title: ':headphones: Huddle notes: 6/4/26',
+          filetype: 'quip',
+          mimetype: 'application/vnd.slack-docs',
+          url_private_download: `${FILE_BASE}/T-F_CANVAS/download/canvas`,
+        },
+      ],
+      [{ match: (u) => u.includes('F_CANVAS'), response: { text: CANVAS_HTML } }],
+    );
+    const connector = createSlackConnector({ fetchImpl, closingReaction: 'lock' });
+    const result = await connector.poll({ subscription: SUB, credential: TOKEN, cursor: null });
+
+    const transcripts = transcriptsOf(result.events);
+    expect(transcripts).toHaveLength(1);
+    const p = JSON.parse(transcripts[0].payload as string) as {
+      fidelity: string;
+      format: string;
+      transcript: string;
+    };
+    expect(p.fidelity).toBe('summary');
+    expect(p.format).toBe('canvas');
+    expect(p.transcript).toContain('Decided cache TTL is 60s.');
+    expect(p.transcript).not.toContain('<'); // tags stripped
+  });
+
+  it('prefers the verbatim .vtt over the canvas and never fetches the canvas', async () => {
+    // The canvas download route is intentionally NOT registered: if the
+    // connector tried to fetch it, the mock would throw "no route matched".
+    const fetchImpl = buildFetch(
+      [
+        {
+          id: 'F_VTT',
+          name: 'standup.vtt',
+          filetype: 'text',
+          url_private_download: `${FILE_BASE}/T-F_VTT/download/standup.vtt`,
+        },
+        {
+          id: 'F_CANVAS',
+          title: ':headphones: Huddle notes: 6/4/26',
+          filetype: 'quip',
+          url_private_download: `${FILE_BASE}/T-F_CANVAS/download/canvas`,
+        },
+      ],
+      [{ match: (u) => u.includes('F_VTT'), response: { text: VTT } }],
+    );
+    const connector = createSlackConnector({ fetchImpl, closingReaction: 'lock' });
+    const result = await connector.poll({ subscription: SUB, credential: TOKEN, cursor: null });
+
+    const transcripts = transcriptsOf(result.events);
+    expect(transcripts).toHaveLength(1);
+    expect((JSON.parse(transcripts[0].payload as string) as { fidelity: string }).fidelity).toBe(
+      'verbatim',
+    );
+  });
+
+  it('emits no transcript event for a settled thread with no transcript files', async () => {
+    const fetchImpl = buildFetch([], []);
+    const connector = createSlackConnector({ fetchImpl, closingReaction: 'lock' });
+    const result = await connector.poll({ subscription: SUB, credential: TOKEN, cursor: null });
+    expect(transcriptsOf(result.events)).toHaveLength(0);
+    expect(result.events).toHaveLength(1); // just the closed-thread event
+  });
+});
+
+describe('vttToTranscript / canvasHtmlToText', () => {
+  it('merges consecutive same-speaker cues and drops timing/cue lines', () => {
+    const vtt = [
+      'WEBVTT',
+      '',
+      'id-1/0-0',
+      '00:00:01.000 --> 00:00:02.000',
+      '<v Dana>First.</v>',
+      'id-1/1-0',
+      '00:00:02.000 --> 00:00:03.000',
+      '<v Dana>Second.</v>',
+      'id-1/2-0',
+      '00:00:03.000 --> 00:00:04.000',
+      '<v Eli>Reply.</v>',
+    ].join('\n');
+    expect(vttToTranscript(vtt)).toBe('Dana: First. Second.\nEli: Reply.');
+  });
+
+  it('falls back to caption text for VTT without <v> voice spans', () => {
+    const vtt = ['WEBVTT', '', '1', '00:00:01.000 --> 00:00:02.000', 'plain caption line'].join(
+      '\n',
+    );
+    expect(vttToTranscript(vtt)).toBe('plain caption line');
+  });
+
+  it('strips canvas HTML to readable text', () => {
+    const html = '<div><h1>Title</h1><p>Line&nbsp;one</p><ul><li>bullet</li></ul></div>';
+    const text = canvasHtmlToText(html);
+    expect(text).toContain('Title');
+    expect(text).toContain('Line one');
+    expect(text).toContain('bullet');
+    expect(text).not.toContain('<');
   });
 });


### PR DESCRIPTION
## What

Extends the existing `:hive:`-gated Slack connector to capture **huddle/meeting transcripts**, not just thread text.

When Slack transcription is on, Slack auto-posts a meeting's verbatim transcript into the channel as an ordinary `.vtt` file (plus an AI-notes `quip` canvas summary). Both are shared into a channel the bot belongs to, so the bot can download them with `files:read`. On a `:hive:`-reacted root, the connector now scans the thread's file attachments, downloads any transcript, normalizes it, and emits a terminal `huddle.transcript` event that the generic terminal-event curator segments per-topic.

## Empirically verified

Tested against a real production bot token (not theory):
- `files.info` → `url_private_download` → `GET` with `Bearer` → **HTTP 200** on a 368 KB WebVTT with speaker labels (`<v Name>…</v>`).
- The AI-notes canvas (`quip`) is likewise bot-readable (summary fallback).
- Slack's native `huddle_transcript` object is **not** bot-readable (302→login: it's shared only into the canvas's internal channel). The connector deliberately ignores it and consumes the in-channel `.vtt` instead.

## Changes (all in `slack.ts`)

- `SlackMessage` carries `files[]` (Slack returns `url_private*` inline — no extra `files.info` hop).
- `classifyTranscriptFile` — `.vtt`/`.srt` → verbatim; AI-notes canvas → summary fallback.
- `fetchFileContent` — raw `files.slack.com` GET with `redirect: 'manual'`, so a walled file (302) is skipped cleanly instead of having its login HTML parsed as a transcript.
- `vttToTranscript` (merges `<v Speaker>` cues into `Speaker: text` turns, strips cue ids/timestamps) and `canvasHtmlToText`.
- On a `:hive:` root, scan root + replies for transcript files; **verbatim preferred over the canvas**; emit one `huddle.transcript` event per file with the normalized `transcript`.
- The thread fetch is hoisted into `poll()` so the same messages feed both paths — the existing `thread.closed` payload is unchanged.

**No curator-side change** — `flattenPayload` + the generic terminal-event curator segment the payload as-is. No new scopes (`files:read`/`canvases:read` already provisioned on the deployed bot).

## Tests

8 new (injected-`fetchImpl` style, matching `slack.test.ts`): verbatim `.vtt` → event; 302 walled → skipped; canvas-only → summary; verbatim-wins (canvas never fetched); no-files; plus `vttToTranscript`/`canvasHtmlToText` units.

✅ typecheck · ✅ build · ✅ full suite **1337 passed** (122 files).

## Operational dependency

Verbatim `.vtt` only auto-posts when Slack **transcription** is enabled for the huddle (separate toggle from "AI notes"). With AI notes alone, only the summary canvas is produced.

---

Consumer-side feature request + full empirical spike: Anglepoint-Inc/hivedb#35