### PR TITLE
fix: start MCP server when dist/mcp/server.js is launched directly

### DIFF
--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -2,8 +2,10 @@
  * think MCP server — AGT-314
  *
  * Exposes think tools over the Model Context Protocol using stdio transport.
- * Claude Code launches this process on demand via `think mcp`; it MUST NOT
- * be auto-started by the daemon or any other process.
+ * Claude Code launches this process on demand, either via `think mcp` or by
+ * running this file directly (`node dist/mcp/server.js` — the command that
+ * `think mcp install` registers in the MCP config). It MUST NOT be
+ * auto-started by the daemon or any other process.
  *
  * Architecture:
  *   MCP client (Claude Code) ↔ stdio ↔ this process ↔ daemon RPC (Unix socket)
@@ -15,6 +17,9 @@
  * registration table that subsequent tickets append to.
  */
 
+import { realpathSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import {
@@ -178,4 +183,42 @@ export async function runMcpServer(): Promise<void> {
 
   process.on('SIGTERM', () => { shutdown('SIGTERM').catch(() => { process.exit(0); }); });
   process.on('SIGINT',  () => { shutdown('SIGINT').catch(() => { process.exit(0); }); });
+}
+
+// ---------------------------------------------------------------------------
+// Direct-invocation entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * True when this module is the script Node was launched with
+ * (`node dist/mcp/server.js`) rather than imported (`think mcp`, tests).
+ *
+ * `argv1` is resolved through `realpathSync` so a symlinked launch path still
+ * matches the module's real location (Node resolves `import.meta.url` to the
+ * real path when `--preserve-symlinks` is off, the default). Exported for
+ * unit testing.
+ */
+export function isDirectInvocation(argv1: string | undefined, moduleUrl: string): boolean {
+  if (!argv1) return false;
+  const modulePath = fileURLToPath(moduleUrl);
+  let scriptPath: string;
+  try {
+    scriptPath = realpathSync(argv1);
+  } catch {
+    scriptPath = path.resolve(argv1);
+  }
+  return scriptPath === modulePath;
+}
+
+// Self-start when launched directly. `think mcp install` registers
+// `{ command: "node", args: ["…/dist/mcp/server.js"] }` in Claude Code's MCP
+// config, but this module previously only exported runMcpServer without ever
+// calling it — so the configured server loaded the module, did nothing, and
+// exited 0, which Claude Code reports as "MCP error -32000: Connection
+// closed". Imports (the `think mcp` command, tests) are unaffected.
+if (isDirectInvocation(process.argv[1], import.meta.url)) {
+  runMcpServer().catch((err) => {
+    process.stderr.write(`[think mcp] fatal: ${err instanceof Error ? err.message : String(err)}\n`);
+    process.exit(1);
+  });
 }

--- a/packages/cli/tests/mcp/server.test.ts
+++ b/packages/cli/tests/mcp/server.test.ts
@@ -116,13 +116,14 @@ describe('MCP server scaffold — in-process', () => {
 // ---------------------------------------------------------------------------
 
 import { spawn } from 'node:child_process';
-import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const PKG_ROOT = resolve(fileURLToPath(import.meta.url), '..', '..', '..');
 const DIST_INDEX = join(PKG_ROOT, 'dist', 'index.js');
+const DIST_MCP_SERVER = join(PKG_ROOT, 'dist', 'mcp', 'server.js');
 
 describe('MCP server — subprocess stdio', () => {
   it.skipIf(!existsSync(DIST_INDEX))(
@@ -255,5 +256,129 @@ describe('MCP server — subprocess stdio', () => {
     // module graph from dist) under parallel fork-pool load can need well over
     // the old 15s. 15s daemon-ready + 30s tools/list worst case → 45s.
     45_000,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// isDirectInvocation — the guard that self-starts the server when launched
+// as `node dist/mcp/server.js` (the command `think mcp install` registers).
+// ---------------------------------------------------------------------------
+
+describe('isDirectInvocation', () => {
+  async function getHelper() {
+    const { isDirectInvocation } = await import('../../src/mcp/server.js');
+    return isDirectInvocation;
+  }
+
+  it('returns false when argv[1] is undefined (e.g. node REPL)', async () => {
+    const isDirectInvocation = await getHelper();
+    expect(isDirectInvocation(undefined, import.meta.url)).toBe(false);
+  });
+
+  it('returns true when argv[1] is the module path itself', async () => {
+    const isDirectInvocation = await getHelper();
+    // realpathSync: on macOS tmpdir() is a symlink (/var → /private/var);
+    // resolve it up front so the constructed module URL is already real,
+    // matching how Node reports import.meta.url.
+    const dir = realpathSync(mkdtempSync(join(tmpdir(), 'think-direct-')));
+    try {
+      const script = join(dir, 'server.js');
+      writeFileSync(script, '// stand-in module\n');
+      expect(isDirectInvocation(script, pathToFileURL(script).href)).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns true when argv[1] is a symlink to the module path', async () => {
+    const isDirectInvocation = await getHelper();
+    const dir = realpathSync(mkdtempSync(join(tmpdir(), 'think-direct-')));
+    try {
+      const script = join(dir, 'server.js');
+      const link = join(dir, 'server-link.js');
+      writeFileSync(script, '// stand-in module\n');
+      symlinkSync(script, link);
+      expect(isDirectInvocation(link, pathToFileURL(script).href)).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns false when argv[1] is a different script (e.g. the CLI entry)', async () => {
+    const isDirectInvocation = await getHelper();
+    const dir = realpathSync(mkdtempSync(join(tmpdir(), 'think-direct-')));
+    try {
+      const script = join(dir, 'server.js');
+      const other = join(dir, 'index.js');
+      writeFileSync(script, '// stand-in module\n');
+      writeFileSync(other, '// stand-in CLI entry\n');
+      expect(isDirectInvocation(other, pathToFileURL(script).href)).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns false for a nonexistent argv[1] path', async () => {
+    const isDirectInvocation = await getHelper();
+    expect(isDirectInvocation('/nonexistent/script.js', import.meta.url)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Subprocess: spawn `node dist/mcp/server.js` — exactly the command that
+// `think mcp install` writes into Claude Code's MCP config.
+//
+// Regression test: before the direct-invocation guard, this loaded the
+// module, did nothing, and exited 0, which Claude Code surfaced as
+// "MCP error -32000: Connection closed".
+//
+// Skipped unless dist/mcp/server.js exists. Run `npm run build` to enable.
+// ---------------------------------------------------------------------------
+
+describe('MCP server — direct node invocation', () => {
+  it.skipIf(!existsSync(DIST_MCP_SERVER))(
+    'starts the server instead of exiting silently with code 0',
+    async () => {
+      const thinkHome = mkdtempSync(join(tmpdir(), 'think-mcp-direct-'));
+      try {
+        const child = spawn(process.execPath, [DIST_MCP_SERVER], {
+          stdio: ['pipe', 'pipe', 'pipe'],
+          env: { ...process.env, THINK_HOME: thinkHome },
+        });
+
+        let stderr = '';
+        child.stderr.setEncoding('utf8');
+
+        // Pass as soon as the server announces itself on stderr (it may then
+        // fail daemon validation in this bare environment — that's fine, the
+        // bug under test is the silent 0-exit before any code runs). Fail if
+        // the process exits without ever announcing, or hangs silently.
+        const outcome = await new Promise<string>((res) => {
+          const timer = setTimeout(() => {
+            child.kill('SIGKILL');
+            res(`timed out with no [think mcp] output.\nstderr: ${stderr}`);
+          }, 20_000);
+          child.stderr.on('data', (c: string) => {
+            stderr += c;
+            if (stderr.includes('[think mcp]')) {
+              clearTimeout(timer);
+              child.kill('SIGKILL');
+              res('started');
+            }
+          });
+          child.on('close', (code) => {
+            clearTimeout(timer);
+            res(stderr.includes('[think mcp]')
+              ? 'started'
+              : `exited (code=${code}) with no [think mcp] output.\nstderr: ${stderr}`);
+          });
+        });
+
+        expect(outcome).toBe('started');
+      } finally {
+        rmSync(thinkHome, { recursive: true, force: true });
+      }
+    },
+    30_000,
   );
 });


### PR DESCRIPTION
## Problem

`think mcp install` registers this entry in Claude Code's MCP config:

```json
{ "command": "node", "args": ["…/dist/mcp/server.js"] }
```

but `src/mcp/server.ts` only defines and exports `runMcpServer` — nothing ever calls it when the file is the launched script. The configured command loads the module, does nothing, and exits 0, which Claude Code surfaces as:

```
MCP server 'think': failed — MCP error -32000: Connection closed
```

I checked the published tarballs: `dist/mcp/server.js` in 1.11.1, 2.0.0, 2.1.0, and 2.1.1 all have this shape, so every config the installer has ever written is dead on arrival. (The `think mcp` CLI path works fine — it imports the module and calls `runMcpServer()` explicitly.)

## Fix

Add a direct-invocation guard at the bottom of `server.ts`: when `process.argv[1]` (realpath-resolved, so symlinked launch paths still match) equals this module's own path, call `runMcpServer()`. Imports — the `think mcp` command and the test suite — are unaffected.

Fixing it on the server side rather than changing what the installer writes means every config already in the field starts working on package upgrade, with no config rewrite or reinstall needed.

## Tests

- Unit tests for the `isDirectInvocation` guard (undefined argv, self path, symlinked path, different script, nonexistent path).
- A subprocess regression test that spawns `node dist/mcp/server.js` — exactly the installer's command — and asserts the server announces itself instead of exiting silently with code 0 (skipped unless `dist/` is built, matching the existing subprocess test).

Verified end-to-end against a built dist: direct launch now completes the MCP `initialize` handshake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)